### PR TITLE
Use the new magnetic field interface

### DIFF
--- a/ForwardTracking/PHG4HitKalmanFitter.cc
+++ b/ForwardTracking/PHG4HitKalmanFitter.cc
@@ -31,7 +31,9 @@
 #include <phgenfit/Fitter.h>
 #include <phgenfit/PlanarMeasurement.h>
 #include <phgenfit/Track.h>
+
 #include <phgeom/PHGeomUtility.h>
+#include <phfield/PHFieldUtility.h>
 
 #include "PHG4HitKalmanFitter.h"
 
@@ -46,8 +48,7 @@ using namespace std;
 
 PHG4TrackFastSim::PHG4TrackFastSim(const std::string &name) :
 		SubsysReco(name),
-		_truth_container(NULL), _trackmap_out(NULL), _fitter (NULL), _mag_field_file_name("/phenix/upgrades/decadal/fieldmaps/fsPHENIX.2d.root"),
-		 _mag_field_re_scaling_factor(1.), _reverse_mag_field(false), _fit_alg_name("KalmanFitterRefTrack"), _do_evt_display(false),
+		_truth_container(NULL), _trackmap_out(NULL), _fitter (NULL), _fit_alg_name("KalmanFitterRefTrack"), _do_evt_display(false),
 		 _phi_resolution(50E-4), //100um
 		 _r_resolution(1.),
 		 _pat_rec_hit_finding_eff(1.),
@@ -80,10 +81,10 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode *topNode) {
 	CreateNodes(topNode);
 
 	TGeoManager* tgeo_manager = PHGeomUtility::GetTGeoManager(topNode);
-
+  PHField * field = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
 	//_fitter = new PHGenFit::Fitter("sPHENIX_Geo.root","sPHENIX.2d.root", 1.4 / 1.5);
 	_fitter = PHGenFit::Fitter::getInstance(tgeo_manager,
-			_mag_field_file_name.data(), (_reverse_mag_field) ? -1.*_mag_field_re_scaling_factor : _mag_field_re_scaling_factor, "KalmanFitterRefTrack", "RKTrackRep",
+	    field, "KalmanFitterRefTrack", "RKTrackRep",
 			_do_evt_display);
 
 	if (!_fitter) {
@@ -348,7 +349,7 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(
 
 	out_track->set_chisq(chi2);
 	out_track->set_ndf(ndf);
-	out_track->set_charge((_reverse_mag_field) ? -1.*phgf_track->get_charge() : phgf_track->get_charge());
+	out_track->set_charge(phgf_track->get_charge());
 
 	out_track->set_px(mom.Px());
 	out_track->set_py(mom.Py());

--- a/ForwardTracking/PHG4HitKalmanFitter.h
+++ b/ForwardTracking/PHG4HitKalmanFitter.h
@@ -105,30 +105,6 @@ public:
 		_fit_alg_name = fitAlgName;
 	}
 
-	const std::string& get_mag_field_file_name() const {
-		return _mag_field_file_name;
-	}
-
-	void set_mag_field_file_name(const std::string& magFieldFileName) {
-		_mag_field_file_name = magFieldFileName;
-	}
-
-	float get_mag_field_re_scaling_factor() const {
-		return _mag_field_re_scaling_factor;
-	}
-
-	void set_mag_field_re_scaling_factor(float magFieldReScalingFactor) {
-		_mag_field_re_scaling_factor = magFieldReScalingFactor;
-	}
-
-	bool is_reverse_mag_field() const {
-		return _reverse_mag_field;
-	}
-
-	void set_reverse_mag_field(bool reverseMagField) {
-		_reverse_mag_field = reverseMagField;
-	}
-
 	double get_pat_rec_hit_finding_eff() const {
 		return _pat_rec_hit_finding_eff;
 	}
@@ -199,15 +175,6 @@ private:
 	 *	GenFit fitter interface
 	 */
 	PHGenFit::Fitter* _fitter;
-
-	//!
-	std::string _mag_field_file_name;
-
-	//! rescale mag field, modify the original mag field read in
-	float _mag_field_re_scaling_factor;
-
-	//! Switch to reverse Magnetic field
-	bool _reverse_mag_field;
 
 	//!
 	std::string _fit_alg_name;

--- a/HF-Jet/HFDiJetMomImbalance/BDiJetModule.C
+++ b/HF-Jet/HFDiJetMomImbalance/BDiJetModule.C
@@ -14,6 +14,7 @@
 #include <phool/PHNodeIterator.h>
 
 #include <phgeom/PHGeomUtility.h>
+#include <phfield/PHFieldUtility.h>
 
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -110,9 +111,6 @@ BDiJetModule::BDiJetModule(const std::string &name,
   _cut_jet_pT(10.0),
   _cut_jet_eta(0.7),
   _cut_jet_R(0.4),
-  _mag_field_file_name("/phenix/upgrades/decadal/fieldmaps/sPHENIX.2d.root"),
-  _mag_field_re_scaling_factor(1.4 / 1.5),
-  _reverse_mag_field(true),
   _track_fitting_alg_name("DafRef"),
   _fitter(NULL),
   _vertexing_method("avf-smoothing:1"),
@@ -140,9 +138,9 @@ int BDiJetModule::InitRun(PHCompositeNode *topNode)
 {
 
   TGeoManager* tgeo_manager = PHGeomUtility::GetTGeoManager(topNode);
+  PHField * field = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
 
-  _fitter = PHGenFit::Fitter::getInstance(tgeo_manager, _mag_field_file_name.data(),
-                                          (_reverse_mag_field) ? -1. * _mag_field_re_scaling_factor : _mag_field_re_scaling_factor,
+  _fitter = PHGenFit::Fitter::getInstance(tgeo_manager, field,
                                           _track_fitting_alg_name, "RKTrackRep", _do_evt_display);
 
   if (!_fitter) {

--- a/HF-Jet/HFDiJetMomImbalance/BDiJetModule.h
+++ b/HF-Jet/HFDiJetMomImbalance/BDiJetModule.h
@@ -151,11 +151,6 @@ private:
   double _cut_jet_eta;               //! Cut on jet eta
   double _cut_jet_R;                 //! Cut on jet R
 
-  std::string _mag_field_file_name;   //! File name for magnetic field map
-  float _mag_field_re_scaling_factor; //! rescale mag field, modify the original mag field read in
-  bool _reverse_mag_field;            //! Switch to reverse Magnetic field
-
-
   std::string _track_fitting_alg_name;
   PHGenFit::Fitter* _fitter;
 

--- a/Tracking/GenFitTrackProp/GenFitTrackProp.cc
+++ b/Tracking/GenFitTrackProp/GenFitTrackProp.cc
@@ -17,6 +17,7 @@
 #include <phool/phool.h>
 #include <phool/getClass.h>
 #include <phgeom/PHGeomUtility.h>
+#include <phfield/PHFieldUtility.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4TruthInfoContainer.h>
@@ -61,9 +62,6 @@ GenFitTrackProp::GenFitTrackProp(const string &name, const int pid_guess) :
 		SubsysReco(name),
 
 		_fitter(nullptr),
-		_mag_field_file_name("/phenix/upgrades/decadal/fieldmaps/sPHENIX.2d.root"),
-		_reverse_mag_field(true),
-		_mag_field_re_scaling_factor(1.4/1.5),
 		_track_fitting_alg_name("DafRef"),
 		_do_evt_display(false),
 
@@ -134,12 +132,10 @@ int GenFitTrackProp::End(PHCompositeNode *topNode) {
 int GenFitTrackProp::InitRun(PHCompositeNode *topNode) {
 
 	TGeoManager* tgeo_manager = PHGeomUtility::GetTGeoManager(topNode);
+  PHField * field = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
 
 	_fitter = PHGenFit::Fitter::getInstance(tgeo_manager,
-			_mag_field_file_name.data(),
-			(_reverse_mag_field) ?
-					-1. * _mag_field_re_scaling_factor :
-					_mag_field_re_scaling_factor, _track_fitting_alg_name,
+	    field, _track_fitting_alg_name,
 			"RKTrackRep", _do_evt_display);
 
 	_fitter->set_verbosity(verbosity);
@@ -231,7 +227,6 @@ void GenFitTrackProp::fill_tree(PHCompositeNode *topNode) {
 		int reco_charge = track->get_charge();
 		int gues_charge = pdg->GetParticle(_pid_guess)->Charge();
 		if(reco_charge*gues_charge<0) _pid_guess *= -1;
-		if(_reverse_mag_field) _pid_guess *= -1;
 
 		genfit::AbsTrackRep* rep = new genfit::RKTrackRep(_pid_guess);
 

--- a/Tracking/GenFitTrackProp/GenFitTrackProp.h
+++ b/Tracking/GenFitTrackProp/GenFitTrackProp.h
@@ -98,10 +98,6 @@ class GenFitTrackProp: public SubsysReco
   //! Needed to initialize genfit::FieldManager and genfit::MaterialEffect
   PHGenFit::Fitter* _fitter;
 
-  std::string _mag_field_file_name;
-  bool _reverse_mag_field;
-  float _mag_field_re_scaling_factor;
-
   std::string _track_fitting_alg_name;
 
   bool _do_evt_display;


### PR DESCRIPTION
Updating analysis modules to use magnetic field configuration stored on DST, which make them consistent with the field used in simulation stages. This requires https://github.com/sPHENIX-Collaboration/coresoftware/pull/349 to work. 

Attn: @HaiwangYu @damcglinchey @johnlajoie 