### PR TITLE
Heavy Flavor analysis script update

### DIFF
--- a/HF-Particle/KFParticle_sPHENIX/makeCondorJobs.py
+++ b/HF-Particle/KFParticle_sPHENIX/makeCondorJobs.py
@@ -1,24 +1,24 @@
-import os
+import sys, os
 
-def makeCondorJob(quarkFilter = "Charm"):
-    inputFileList = "fileList_MDC_" + quarkFilter + ".txt"
+def makeCondorJob(quarkFilter):
+    print("Creating condor submission files for {} production".format(quarkFilter))
+    inputFileList = "dst_hf_" + quarkFilter.lower() + ".list"
     infile = open(inputFileList, "r")
     line = infile.readline()
+    myOutputPath = os.getcwd()
     while line:
-        line = infile.readline()
         splitLine = line.split("/")
         fileName = splitLine[-1]
         fileName = fileName.replace('\n', '')
         productionNumber = line[-11: -6]
 
-        myOutputPath = os.getcwd()
         os.makedirs("{}/condorJobs/log".format(myOutputPath), exist_ok=True)
         condorOutputInfo = "{0}/condorJobs/log/condor-{1}-{2}".format(myOutputPath, quarkFilter, productionNumber)
 
         condorFileName = open("condorJobs/condorJob_" + quarkFilter + "_" + productionNumber + ".job", "w")
         condorFileName.write("Universe        = vanilla\n")
         condorFileName.write("Executable      = {}/run_KFParticle.sh\n".format(myOutputPath))
-        condorFileName.write("Arguments       = \"/sphenix/user/cdean/MDC1/pythia8/HeavyFlavorTG/data {}\"\n".format(fileName))
+        condorFileName.write("Arguments       = \"/sphenix/sim/sim01/sphnxpro/MDC1/HF_pp200_signal/data {}\"\n".format(fileName))
         condorFileName.write("Output          = {0}.out\n".format(condorOutputInfo))
         condorFileName.write("Error           = {0}.err\n".format(condorOutputInfo))
         condorFileName.write("Log             = {0}.log\n".format(condorOutputInfo))
@@ -28,5 +28,16 @@ def makeCondorJob(quarkFilter = "Charm"):
         condorFileName.write("Priority        = 20\n")
         condorFileName.write("job_lease_duration = 3600\n")
         condorFileName.write("Queue 1\n")
+        line = infile.readline()
+    print("Condor submission files have been written to {}/condorJobs".format(myOutputPath))
         
-makeCondorJob()
+nArgs = len(sys.argv)
+
+if nArgs == 1 or sys.argv[1].upper() == "CHARM":
+    os.system("CreateFileList.pl -type 7 DST_HF_CHARM")
+    makeCondorJob("CHARM")
+elif sys.argv[1].upper() == "BOTTOM":
+    os.system("CreateFileList.pl -type 8 DST_HF_BOTTOM")
+    makeCondorJob("BOTTOM")
+else:
+    print("The argument, {}, was not known".format(sys.argv[1]))

--- a/HF-Particle/KFParticle_sPHENIX/run_KFParticle.sh
+++ b/HF-Particle/KFParticle_sPHENIX/run_KFParticle.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/bash
 export HOME=/sphenix/u/${LOGNAME}
-source /opt/sphenix/core/bin/sphenix_setup.sh -n new
+source /opt/sphenix/core/bin/sphenix_setup.sh -n mdc1.5
 
 echo running: run_KFParticle.sh $*
 
-#echo 'here comes your environment'
-#printenv
 echo arg1 \(file path\) : $1
 echo arg2 \(file name\) : $2
 echo running root.exe -q -b Fun4All_KFParticle_singleFile.C\(\"$1\",\"$2\"\)


### PR DESCRIPTION
The condor submission script examples for the HFTG are updated to use the MDC1 production information. The python script makeCondorJobs will now take an argument to use either the charm or bottom filtered samples. With this it will make a file list from Chris' CreateFileList.pl and a condor submission script for each DST in our bookkeeping. This way we shouldnt have to continuously update file lists.

run_KFParticle.sh will now source MDC 1.5 which is the production version.

More information is available at: https://wiki.bnl.gov/sPHENIX/index.php/Heavy_Flavor_Topical_Group#Mock_Data_Challenge_1