### PR TITLE
First iteration of heavy flavor trigger

### DIFF
--- a/HF-Particle/HFTrigger/HFTrigger.cc
+++ b/HF-Particle/HFTrigger/HFTrigger.cc
@@ -1,0 +1,316 @@
+#include "HFTrigger.h"
+
+/*
+ * Basic heavy flavor software trigger
+ * Used in study of hardware trigger
+ * Cameron Dean
+ * 01/02/2021
+ */
+std::map<std::string, bool> triggerDecisions =
+{
+  {"oneTrack", false}
+, {"twoTrack", false}
+, {"lowMultiplicity", false}
+, {"highMultiplicity", false}
+};
+
+namespace HFTriggerRequirement
+{
+  float meanHighMult = 100; //Set min num. INTT hits
+  float asymmHighMult = 0.1; //Set highMult asymm between INTT layers (fraction)
+  float meanLowMult = 20;  //Set max num. INTT hits
+  float asymmLowMult = 0.1; //Set lowMult asymm between INTT layers (fraction)
+  float trackPT = 0.5; //Min track pT in GeV
+  float trackVertexDCA = 0.01; //Min. DCA of a track with any vertex in cm
+  float trackTrackDCA = 0.03; //Max. DCA of a track with other tracks in cm
+}
+
+HFTrigger::HFTrigger()
+  : SubsysReco("HFTRIGGER")
+  , m_useOneTrackTrigger(false)
+  , m_useTwoTrackTrigger(false)
+  , m_useLowMultiplicityTrigger(false)
+  , m_useHighMultiplicityTrigger(false)
+{
+}
+
+HFTrigger::HFTrigger(const std::string &name)
+  : SubsysReco(name)
+  , m_useOneTrackTrigger(false)
+  , m_useTwoTrackTrigger(false)
+  , m_useLowMultiplicityTrigger(false)
+  , m_useHighMultiplicityTrigger(false)
+{
+}
+
+int HFTrigger::Init(PHCompositeNode *topNode)
+{
+  return 0;
+}
+
+int HFTrigger::process_event(PHCompositeNode *topNode)
+{
+  bool successfulTrigger = runTrigger(topNode);
+  
+  if (Verbosity() >= VERBOSITY_SOME) 
+  {
+    if (successfulTrigger) std::cout << "One of the heavy flavor triggers fired" << std::endl;
+    else std::cout << "No heavy flavor triggers fired" << std::endl;
+  }
+
+  if (m_useOneTrackTrigger && !triggerDecisions.find("oneTrack")->second)
+  {
+    if (Verbosity() >= VERBOSITY_SOME) std::cout << "The oneTrackTrigger did not fire for this event, skipping." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  if (m_useTwoTrackTrigger && !triggerDecisions.find("twoTrack")->second)
+  {
+    if (Verbosity() >= VERBOSITY_SOME) std::cout << "The twoTrackTrigger did not fire for this event, skipping." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  if (m_useLowMultiplicityTrigger && !triggerDecisions.find("lowMultiplicity")->second)
+  {
+    if (Verbosity() >= VERBOSITY_SOME) std::cout << "The lowMultiplicityTrigger did not fire for this event, skipping." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  if (m_useHighMultiplicityTrigger && !triggerDecisions.find("highMultiplicity")->second)
+  {
+    if (Verbosity() >= VERBOSITY_SOME) std::cout << "The highMultiplicityTrigger did not fire for this event, skipping." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int HFTrigger::End(PHCompositeNode *topNode)
+{
+  return 0;
+}
+
+bool HFTrigger::runTrigger(PHCompositeNode *topNode)
+{
+  bool anyTriggerFired = false;
+
+  std::vector<Track> allTracks = makeAllTracks(topNode);
+  std::vector<Vertex> allVertices = makeAllPrimaryVertices(topNode);
+
+  float meanMult = 0;
+  float asymmMult = 0;
+  calculateMultiplicity(topNode, meanMult, asymmMult);  
+
+  if (m_useOneTrackTrigger) triggerDecisions.find("oneTrack")->second = runOneTrackTrigger(allTracks, allVertices);
+  if (m_useTwoTrackTrigger) triggerDecisions.find("twoTrack")->second = runTwoTrackTrigger(allTracks, allVertices);
+  if (m_useLowMultiplicityTrigger) triggerDecisions.find("lowMultiplicity")->second = runLowMultiplicityTrigger(meanMult, asymmMult);
+  if (m_useHighMultiplicityTrigger) triggerDecisions.find("highMultiplicity")->second = runHighMultiplicityTrigger(meanMult, asymmMult);
+
+  if (Verbosity() >= VERBOSITY_SOME) printTrigger();
+
+  const int numberOfFiredTriggers = std::accumulate( begin(triggerDecisions), end(triggerDecisions), 0, 
+                                                   [](const int previous, const std::pair<const std::string, bool>& element) 
+                                                   { return previous + element.second; });
+
+  if (numberOfFiredTriggers != 0) anyTriggerFired = true;
+
+  return anyTriggerFired;
+}
+
+bool HFTrigger::runOneTrackTrigger(std::vector<Track> Tracks, std::vector<Vertex> Vertices)
+{ //Can maybe use return when we get a positive trigger decision to break the loops
+  bool oneTrackTriggerDecision = false;
+
+  for (Track track : Tracks)
+  {
+    float pT = sqrt(pow(track(3,0), 2) + pow(track(4,0), 2));
+    float minIP = FLT_MAX;
+    for (Vertex vertex : Vertices)
+    {
+      float thisIP = calcualteTrackVertexDCA(track, vertex);
+      minIP = std::min(minIP, thisIP);
+    }
+    if (pT > HFTriggerRequirement::trackPT && minIP > HFTriggerRequirement::trackVertexDCA) oneTrackTriggerDecision = true;
+  }
+
+  return oneTrackTriggerDecision;
+}
+
+bool HFTrigger::runTwoTrackTrigger(std::vector<Track> Tracks, std::vector<Vertex> Vertices)
+{
+  bool twoTrackTriggerDecision = false;
+  std::vector<Track> goodTracks;
+
+  for (Track track : Tracks)
+  {
+    std::vector<Track> singleTrack = {track};
+    bool oneTrackTriggerDecision = runOneTrackTrigger(singleTrack, Vertices);
+    if (oneTrackTriggerDecision) goodTracks.push_back(track);
+  }
+
+  if (goodTracks.size() > 1) //We need at least two good track to start a two track trigger
+  {
+    for (unsigned int i = 0; i < goodTracks.size(); i++)
+    {
+      for (unsigned int j = i + 1; j < goodTracks.size(); j++)
+      {
+        float trackDCA = calcualteTrackTrackDCA(goodTracks[i], goodTracks[j]);
+        if (trackDCA < HFTriggerRequirement::trackTrackDCA) twoTrackTriggerDecision = true;
+      } 
+    }
+  }
+
+  return twoTrackTriggerDecision;
+}
+
+void HFTrigger::calculateMultiplicity(PHCompositeNode *topNode, float& meanMultiplicity, float& asymmetryMultiplicity)
+{
+  TrkrHitSetContainer* hitContainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
+
+  TrkrHitSetContainer::ConstRange inttHitSetRange[2];
+  for (int i = 0; i < 2; i++) inttHitSetRange[i] = hitContainer->getHitSets(TrkrDefs::TrkrId::inttId, i + 4);
+
+  int inttHits[2] = {0};
+
+  for (int i = 0; i < 2; i++) 
+  {
+    for (TrkrHitSetContainer::ConstIterator hitsetitr = inttHitSetRange[i].first;
+         hitsetitr != inttHitSetRange[i].second;
+         ++hitsetitr)
+    {
+      TrkrHitSet *hitset = hitsetitr->second;
+      inttHits[i] += hitset->size();
+    }
+  }
+
+
+  meanMultiplicity = (inttHits[0] + inttHits[1])/2;
+  asymmetryMultiplicity = (inttHits[0] - inttHits[1])/(inttHits[0] + inttHits[1]);
+}
+
+bool HFTrigger::runHighMultiplicityTrigger(float meanMultiplicity, float asymmetryMultiplicity)
+{
+  bool multiplicityTriggerDecision = false;
+  float meanRequirement = HFTriggerRequirement::meanHighMult;
+  float asymmRequirement = HFTriggerRequirement::asymmHighMult;
+
+  if ( meanMultiplicity > meanRequirement && asymmetryMultiplicity < asymmRequirement)
+    multiplicityTriggerDecision = true;
+
+  return multiplicityTriggerDecision;
+}
+
+bool HFTrigger::runLowMultiplicityTrigger(float meanMultiplicity, float asymmetryMultiplicity)
+{
+  bool multiplicityTriggerDecision = false;
+  float meanRequirement = HFTriggerRequirement::meanLowMult;
+  float asymmRequirement = HFTriggerRequirement::asymmLowMult;
+
+  if ( meanMultiplicity < meanRequirement && asymmetryMultiplicity < asymmRequirement)
+    multiplicityTriggerDecision = true;
+
+  return multiplicityTriggerDecision;
+}
+
+Vertex HFTrigger::makeVertex(PHCompositeNode *topNode)
+{
+  Vertex vertex;
+
+  vertex(0,0) = m_dst_vertex->get_x();
+  vertex(1,0) = m_dst_vertex->get_y();
+  vertex(2,0) = m_dst_vertex->get_z();
+
+  return vertex;
+}
+
+std::vector<Vertex> HFTrigger::makeAllPrimaryVertices(PHCompositeNode *topNode)
+{
+  std::vector<Vertex> primaryVertices;
+  m_dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+
+  for (SvtxVertexMap::ConstIter iter = m_dst_vertexmap->begin(); iter != m_dst_vertexmap->end(); ++iter)
+  {
+    m_dst_vertex = iter->second;
+    primaryVertices.push_back(makeVertex(topNode));
+  }
+
+  return primaryVertices;
+}
+
+Track HFTrigger::makeTrack(PHCompositeNode *topNode)  
+{
+  Track track;
+
+  track(0,0) = m_dst_track->get_x();
+  track(1,0) = m_dst_track->get_y();
+  track(2,0) = m_dst_track->get_z();
+  track(3,0) = m_dst_track->get_px();
+  track(4,0) = m_dst_track->get_py();
+  track(5,0) = m_dst_track->get_pz();
+
+  return track;
+}
+
+std::vector<Track> HFTrigger::makeAllTracks(PHCompositeNode *topNode)
+{
+  std::vector<Track> tracks;
+  m_dst_trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+
+  for (SvtxTrackMap::Iter iter = m_dst_trackmap->begin(); iter != m_dst_trackmap->end(); ++iter)
+  {
+    m_dst_track = iter->second;
+    tracks.push_back(makeTrack(topNode));  
+  }
+
+  return tracks;
+}
+
+int HFTrigger::decomposeTrack(Track track, TrackX& trackPosition, TrackP& trackMomentum)
+{
+  for (unsigned int i = 0; i < 3; i++)
+  {
+    trackPosition(i,0) = track(i,0);
+    trackMomentum(i,0) = track(i+3,0);
+  }
+
+  return 0;
+}
+
+float HFTrigger::calcualteTrackVertexDCA(Track track, Vertex vertex)
+{
+  TrackX pos;
+  TrackP mom;
+  DCA dcaVertex;
+
+  decomposeTrack(track, pos, mom);
+
+  dcaVertex = pos - vertex - mom.dot(pos - vertex)*mom/(mom.dot(mom));
+  
+  return std::abs(dcaVertex.norm());
+}
+
+float HFTrigger::calcualteTrackTrackDCA(Track trackOne, Track trackTwo)
+{
+  TrackX posOne;
+  TrackP momOne;
+  TrackX posTwo;
+  TrackP momTwo;
+  float dcaTrackSize;
+
+  decomposeTrack(trackOne, posOne, momOne);
+  decomposeTrack(trackTwo, posTwo, momTwo);
+
+  Eigen::Vector3f momOneCrossmomTwo = momOne.cross(momTwo);
+  Eigen::Vector3f posOneMinusposTwo = posOne - posTwo;
+  dcaTrackSize = std::abs(momOneCrossmomTwo.dot(posOneMinusposTwo)/(momOneCrossmomTwo.norm()));
+  
+  return dcaTrackSize;
+}
+
+void HFTrigger::printTrigger()
+{
+  std::cout << "\n---------------HFTrigger information---------------" << std::endl;
+  if (m_useOneTrackTrigger) std::cout << "The oneTrack trigger decision is " << triggerDecisions.find("oneTrack")->second << std::endl;
+  if (m_useTwoTrackTrigger) std::cout << "The twoTrack trigger decision is " << triggerDecisions.find("twoTrack")->second << std::endl;
+  if (m_useLowMultiplicityTrigger) std::cout << "The lowMultiplicity trigger decision is " << triggerDecisions.find("lowMultiplicity")->second << std::endl;
+  if (m_useHighMultiplicityTrigger) std::cout << "The highMultiplicity trigger decision is " << triggerDecisions.find("highMultiplicity")->second << std::endl;
+  std::cout << "---------------------------------------------------\n" << std::endl;
+}
+

--- a/HF-Particle/HFTrigger/HFTrigger.h
+++ b/HF-Particle/HFTrigger/HFTrigger.h
@@ -1,0 +1,106 @@
+#ifndef HFTRIGGER_H
+#define HFTRIGGER_H
+
+//sPHENIX stuff
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>
+#include <phool/getClass.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContainer.h>
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxVertex.h>
+#include <trackbase_historic/SvtxVertexMap.h>
+
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include <cfloat>
+#include <cmath>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <string>
+
+typedef Eigen::Matrix<float, 6, 1> Track;
+typedef Eigen::Matrix<float, 3, 1> Vertex;
+typedef Eigen::Matrix<float, 3, 1> TrackX;
+typedef Eigen::Matrix<float, 3, 1> TrackP;
+typedef Eigen::Matrix<float, 3, 1> DCA;
+
+/*
+class PHCompositeNode;
+
+class SvtxVertexMap;
+class SvtxTrackMap;
+class SvtxVertex;
+class SvtxTrack;
+*/
+class HFTrigger : public SubsysReco
+{
+ public:
+  HFTrigger();
+
+  explicit HFTrigger(const std::string &name);
+
+  virtual ~HFTrigger(){}
+
+  int Init(PHCompositeNode *topNode);
+
+  int process_event(PHCompositeNode *topNode);
+
+  int End(PHCompositeNode *topNode);
+
+  bool runTrigger(PHCompositeNode *topNode);
+
+  bool runOneTrackTrigger(std::vector<Track> Tracks, std::vector<Vertex> Vertices);
+
+  bool runTwoTrackTrigger(std::vector<Track> Tracks, std::vector<Vertex> Vertices);
+
+  bool runMultiplicityTrigger(PHCompositeNode *topNode);
+
+  void calculateMultiplicity(PHCompositeNode *topNode, float& meanMultiplicity, float& asymmetryMultiplicity);
+
+  bool runHighMultiplicityTrigger(float meanMultiplicity, float asymmetryMultiplicity);
+
+  bool runLowMultiplicityTrigger(float meanMultiplicity, float asymmetryMultiplicity);
+
+  Vertex makeVertex(PHCompositeNode *topNode);
+
+  std::vector<Vertex> makeAllPrimaryVertices(PHCompositeNode *topNode);
+
+  Track makeTrack(PHCompositeNode *topNode);
+
+  std::vector<Track> makeAllTracks(PHCompositeNode *topNode);
+
+  int decomposeTrack(Track track, TrackX& trackPosition, TrackP& trackMomentum);
+
+  float calcualteTrackVertexDCA(Track track, Vertex vertex);
+
+  float calcualteTrackTrackDCA(Track trackOne, Track trackTwo);
+
+  void printTrigger();
+
+  //User configuration
+  void requireOneTrackTrigger(bool useTrigger) { m_useOneTrackTrigger = useTrigger; }
+  void requireTwoTrackTrigger(bool useTrigger) { m_useTwoTrackTrigger = useTrigger; }
+  void requireLowMultiplicityTrigger(bool useTrigger) { m_useLowMultiplicityTrigger = useTrigger; }
+  void requireHighMultiplicityTrigger(bool useTrigger) { m_useHighMultiplicityTrigger = useTrigger; }
+ 
+ protected:
+
+ private:
+
+  bool m_useOneTrackTrigger = false;
+  bool m_useTwoTrackTrigger = false;
+  bool m_useLowMultiplicityTrigger = false;
+  bool m_useHighMultiplicityTrigger = false;
+
+  SvtxVertexMap *m_dst_vertexmap = nullptr;
+  SvtxTrackMap *m_dst_trackmap = nullptr;
+  SvtxVertex *m_dst_vertex = nullptr;
+  SvtxTrack *m_dst_track = nullptr;
+};
+
+#endif  //HFTRIGGER_H

--- a/HF-Particle/HFTrigger/Makefile.am
+++ b/HF-Particle/HFTrigger/Makefile.am
@@ -1,0 +1,55 @@
+AUTOMAKE_OPTIONS = foreign
+
+lib_LTLIBRARIES = \
+    libhftrigger.la
+
+AM_LDFLAGS = \
+  -L$(libdir) 
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -I$(ROOTSYS)/include \
+  -I$(OFFLINE_MAIN)/include/eigen3
+
+pkginclude_HEADERS = \
+  HFTrigger.h
+
+libhftrigger_la_SOURCES = \
+  HFTrigger.cc
+
+libhftrigger_la_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -I$(ROOTSYS)/include \
+  -I$(OFFLINE_MAIN)/include/eigen3 \
+  -lfun4all \
+  -lg4eval 
+
+# Rule for generating table CINT dictionaries.
+%_Dict.cc: %.h %LinkDef.h
+	rootcint -f $@ @CINTDEFS@ $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+
+#just to get the dependency
+%_Dict_rdict.pcm: %_Dict.cc ;
+
+################################################
+# linking tests
+
+noinst_PROGRAMS = \
+  testexternals 
+
+BUILT_SOURCES = testexternals.cc
+
+testexternals_SOURCES = testexternals.cc
+testexternals_LDADD = libhftrigger.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f *Dict* $(BUILT_SOURCES) *.pcm

--- a/HF-Particle/HFTrigger/autogen.sh
+++ b/HF-Particle/HFTrigger/autogen.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure "$@"

--- a/HF-Particle/HFTrigger/configure.ac
+++ b/HF-Particle/HFTrigger/configure.ac
@@ -1,0 +1,21 @@
+AC_INIT(hftrigger,[0.01])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+AC_PROG_CXX(CC g++)
+LT_INIT([disable-static])
+
+case $CXX in
+  clang++)
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-macro-redefined"
+  ;;
+  g++)
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+  ;;
+esac
+
+CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+AC_SUBST(CINTDEFS)
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/HF-Particle/KFParticle_sPHENIX/Fun4All_KFParticle_advanced.C
+++ b/HF-Particle/KFParticle_sPHENIX/Fun4All_KFParticle_advanced.C
@@ -22,10 +22,12 @@
 #include <fun4all/SubsysReco.h>
 #include <phhepmc/Fun4AllHepMCInputManager.h>
 #include <kfparticle_sphenix/KFParticle_sPHENIX.h>
+#include <hftrigger/HFTrigger.h>
 #include <numeric>
 #include <trackreco/PHRaveVertexing.h>
 
 R__LOAD_LIBRARY(libkfparticle_sphenix.so)
+R__LOAD_LIBRARY(libhftrigger.so)
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libg4dst.so)
 R__LOAD_LIBRARY(libg4eval.so)
@@ -68,8 +70,9 @@ int Fun4All_KFParticle_advanced(){
   //---------------
   // Choose reco
   //---------------
-  bool use_act_tracking = true;
-  bool use_rave_vertexing = true;
+  bool use_act_tracking = false;
+  bool use_rave_vertexing = false;
+  bool use_trigger = true;
 
   map<string, int> reconstructionChannel;
   reconstructionChannel["D02K-pi+"] = 1;
@@ -108,8 +111,20 @@ int Fun4All_KFParticle_advanced(){
   if (reconstructionChannel["Bs2Jpsiphi"]) fileList = "fileList_bs2jpsiphi.txt";
   if (reconstructionChannel["Bd2D-pi+"] or reconstructionChannel["Upsilon"]) fileList = "fileList_bbbar.txt";
   hitsin->AddListFile(fileList.c_str());
+  //hitsin->AddFile("/sphenix/user/cdean/MDC1/pythia8/HeavyFlavorTG/data/fullProduction/DST_HF_CHARM_pythia8-0000000001-00000.root");
+  //hitsin->AddFile("/sphenix/sim/sim01/sphnxpro/MDC1/sHijing_HepMC/DST/DST_sHijing_0_12fm-0000000001-00000.root");
   se->registerInputManager(hitsin);
 
+  if (use_trigger)
+  {
+    HFTrigger* myTrigger = new HFTrigger("myTestTrigger");
+    myTrigger->Verbosity(verbosity);
+    myTrigger->requireOneTrackTrigger(true);
+    myTrigger->requireTwoTrackTrigger(true);
+    myTrigger->requireLowMultiplicityTrigger(true);
+    se->registerSubsystem(myTrigger);
+  }
+ 
 
   if (use_act_tracking)
   {


### PR DESCRIPTION
This PR adds a VERY basic heavy flavor trigger. This is part of a study on a hardware trigger. To this end, the triggers here use simple quantities: track-vertex DCA, track-track DCA, track pT and nHits in INTT.

There are four triggers that can be enabled: a one track trigger, a two track trigger (which calls the one track trigger), a low multiplicity trigger and a high multiplicity trigger. You can enable multiple triggers but they are all required to trigger in your event to enable processing so be careful for now. We also trigger independent of your signal (TIS) not on the signal (TOS). There is also no appending back to the node tree here, if your trigger on the event you process the event, if not then you skip it. This means you have to run the trigger everytime you run Fun4All (no pre-processing available).

This trigger works on reconstructed tracks, I would like to keep this as an option and work on triggering on raw hits. THis means we can port the trigger into full reconstruction if needed later.

Example (from Fun4All_KFParticle_advanced.C):

R__LOAD_LIBRARY(libhftrigger.so)

  bool use_trigger = true;
  if (use_trigger)
  {
    HFTrigger* myTrigger = new HFTrigger("myTestTrigger");
    myTrigger->Verbosity(verbosity);
    myTrigger->requireOneTrackTrigger(true);
    myTrigger->requireTwoTrackTrigger(true);
    myTrigger->requireLowMultiplicityTrigger(true);
    se->registerSubsystem(myTrigger);
  }