### PR TITLE
Calibration Modification

### DIFF
--- a/EMCal-position-dependent-calibration/example/macro/Fun4All_G4_sPHENIX.C
+++ b/EMCal-position-dependent-calibration/example/macro/Fun4All_G4_sPHENIX.C
@@ -51,11 +51,12 @@ R__LOAD_LIBRARY(libEMCalPositionDependentCalibration.so)
 int Fun4All_G4_sPHENIX(
     const int nEvents = 1,
     const int seed = 0,
+    const string &calib_path="CEMC/PositionRecalibrationFull/",
+    const string &outdir = ".",
     const string &inputFile = "https://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/sPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root",
     const string &outputFile = "G4sPHENIX.root",
     const string &embed_input_file = "https://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/sPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root",
-    const int skip = 0,
-    const string &outdir = ".")
+    const int skip = 0)
 {
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(1);
@@ -475,7 +476,7 @@ int Fun4All_G4_sPHENIX(
 
   if (Enable::CEMC_TOWER) CEMC_Towers();
   if (Enable::CEMC_CLUSTER) CEMC_Clusters();
-  if (Enable::CEMC_CLUSTER_FULL) CEMC_Clusters_Full();
+  if (Enable::CEMC_CLUSTER_FULL) CEMC_Clusters_Full(calib_path);
 
   //-----------------------------
   // HCAL towering and clustering

--- a/EMCal-position-dependent-calibration/macro/CEmc_Spacal.C
+++ b/EMCal-position-dependent-calibration/macro/CEmc_Spacal.C
@@ -10,7 +10,7 @@ namespace Enable
     bool CEMC_EVAL_POSITION_CORRECTION = false;
 }  // namespace Enable
 
-void CEMC_Clusters_Full()
+void CEMC_Clusters_Full(const string &calib_path="CEMC/PositionRecalibrationFull/")
 {
     int verbosity = std::max(Enable::VERBOSITY, Enable::CEMC_VERBOSITY);
 
@@ -50,10 +50,10 @@ void CEMC_Clusters_Full()
     {
         clusterCorrection->Get_eclus_CalibrationParameters().ReadFromFile("CEMC_RECALIB", "xml", 0, 0,
                 //raw location
-                string(getenv("CALIBRATIONROOT")) + string("/CEMC/PositionRecalibrationFull/"));
+                string(getenv("CALIBRATIONROOT")) + string("/") + calib_path);
         clusterCorrection->Get_ecore_CalibrationParameters().ReadFromFile("CEMC_ECORE_RECALIB", "xml", 0, 0,
                 //raw location
-                string(getenv("CALIBRATIONROOT")) + string("/CEMC/PositionRecalibrationFull/"));
+                string(getenv("CALIBRATIONROOT")) + string("/") + calib_path);
     }
 
     clusterCorrection->Verbosity(verbosity);

--- a/EMCal-position-dependent-calibration/src/CaloEvaluatorPositionCorrection.cc
+++ b/EMCal-position-dependent-calibration/src/CaloEvaluatorPositionCorrection.cc
@@ -116,7 +116,7 @@ int CaloEvaluatorPositionCorrection::Init(PHCompositeNode* /*topNode*/)
   }
 
   if (_do_cluster_eval) _ntp_cluster = new TNtuple("ntp_cluster", "cluster => max truth primary",
-                                                   "event:clusterID:ntowers:eta:x:y:z:phi:e:"
+                                                   "event:clusterID:ntowers:eta_bin:phi_bin:eta_detector:eta:x:y:z:phi:e:"
                                                    "gparticleID:gflavor:gnhits:"
                                                    "geta:gphi:ge:gpt:gvx:gvy:gvz:"
                                                    "gembed:gedep:"
@@ -729,7 +729,10 @@ void CaloEvaluatorPositionCorrection::fillOutputNtuples(PHCompositeNode* topNode
     GlobalVertexMap* vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
 
     string clusternode = "CLUSTER_POS_COR_CEMC";
+    string towernode = "TOWER_CALIB_" + _caloname;
+
     RawClusterContainer* clusters = findNode::getClass<RawClusterContainer>(topNode, clusternode.c_str());
+    RawTowerContainer* _towers = findNode::getClass<RawTowerContainer>(topNode, towernode.c_str());
     if (!clusters)
     {
       cerr << PHWHERE << " ERROR: Can't find " << clusternode << endl;
@@ -741,6 +744,28 @@ void CaloEvaluatorPositionCorrection::fillOutputNtuples(PHCompositeNode* topNode
     for (const auto& iterator : clusters->getClustersMap())
     {
       RawCluster* cluster = iterator.second;
+
+      std::vector<float> toweretas;
+      std::vector<float> towerphis;
+      std::vector<float> towerenergies;
+
+      // loop over the towers in the cluster
+      RawCluster::TowerConstRange towers = cluster->get_towers();
+      RawCluster::TowerConstIterator toweriter;
+
+      for (toweriter = towers.first; toweriter != towers.second; ++toweriter)
+      {
+        RawTower *tower = _towers->getTower(toweriter->first);
+
+        int towereta = tower->get_bineta();
+        int towerphi = tower->get_binphi();
+        double towerenergy = tower->get_energy();
+
+        // put the etabin, phibin, and energy into the corresponding vectors
+        toweretas.push_back(towereta);
+        towerphis.push_back(towerphi);
+        towerenergies.push_back(towerenergy);
+      }
 
       //    for (unsigned int icluster = 0; icluster < clusters->size(); icluster++)
       //    {
@@ -754,8 +779,31 @@ void CaloEvaluatorPositionCorrection::fillOutputNtuples(PHCompositeNode* topNode
       float y = cluster->get_y();
       float z = cluster->get_z();
       float eta = NAN;
+      float eta_detector = NAN;
       float phi = cluster->get_phi();
       float e = cluster->get_energy();
+
+      // loop over the towers to determine the energy
+      // weighted eta and phi position of the cluster
+
+      float etamult = 0;
+      float etasum = 0;
+      float phimult = 0;
+      float phisum = 0;
+
+      for (int j = 0; j < ntowers; j++)
+      {
+        float energymult = towerenergies.at(j) * toweretas.at(j);
+        etamult += energymult;
+        etasum += towerenergies.at(j);
+
+        energymult = towerenergies.at(j) * towerphis.at(j);
+        phimult += energymult;
+        phisum += towerenergies.at(j);
+      }
+
+      float avg_eta_bin = (etasum != 0) ? floorf(etamult / etasum * 1e4)/1e4 : NAN;
+      float avg_phi_bin = (phisum != 0) ? floorf(phimult / phisum * 1e4)/1e4 : NAN;
 
       // require vertex for cluster eta calculation
       if (vertexmap)
@@ -768,6 +816,11 @@ void CaloEvaluatorPositionCorrection::fillOutputNtuples(PHCompositeNode* topNode
               RawClusterUtility::GetPseudorapidity(
                   *cluster,
                   CLHEP::Hep3Vector(vertex->get_x(), vertex->get_y(), vertex->get_z()));
+
+          eta_detector =
+            RawClusterUtility::GetPseudorapidity(
+              *cluster,
+              CLHEP::Hep3Vector(0,0,0));
         }
       }
 
@@ -833,6 +886,9 @@ void CaloEvaluatorPositionCorrection::fillOutputNtuples(PHCompositeNode* topNode
       float cluster_data[] = {(float) _ievent,
                               clusterID,
                               ntowers,
+                              avg_eta_bin,
+                              avg_phi_bin,
+                              eta_detector,
                               eta,
                               x,
                               y,

--- a/EMCal-position-dependent-calibration/src/RawClusterPositionCorrectionFull.h
+++ b/EMCal-position-dependent-calibration/src/RawClusterPositionCorrectionFull.h
@@ -56,6 +56,8 @@ class RawClusterPositionCorrectionFull : public SubsysReco
 
   std::string _det_name;
 
+  const float tower_eta_mid = 47.5;
+
   int bins_eta, bins_phi;
   std::vector<float> binvals_eta;
   std::vector<float> binvals_phi;


### PR DESCRIPTION
- Fun4All_G4_sPHENIX: Added calib_path parameter to specify the calibrations to apply.
- Cemc_Spacal: passing calib_path as a parameter to generalize the behavior of the calibrations.
- CaloEvaluatorPositionCorrection: Adding eta_bin, phi_bin, and eta_detector to keep track of extra information needed to validate the calibrations.
- RawTowerPositionCorrectionFull: Setting tower_eta_mid = 47.5 which represents the point at which detector eta = 0. Precision is set to 4 decimal places which is reliable. Implementing the eta reflection.