### PR TITLE
Simplified Calibration

### DIFF
--- a/EMCal-position-dependent-calibration/example/macro/Fun4All_G4_sPHENIX.C
+++ b/EMCal-position-dependent-calibration/example/macro/Fun4All_G4_sPHENIX.C
@@ -166,10 +166,14 @@ int Fun4All_G4_sPHENIX(
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0.01, 0.01, 5.);
     }
-    INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-1, 1);
-    INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI, M_PI);
-    // INPUTGENERATOR::SimpleEventGenerator[0]->set_pt_range(0.1, 20.);
-    INPUTGENERATOR::SimpleEventGenerator[0]->set_pt_range(5, 5);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(0, 1.1);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI/32.0 - 0.02, M_PI/32.0 + 0.02);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_pt_range(20, 21.);
+
+    // for testing use full range
+    // INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-1, 1);
+    // INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI, M_PI);
+    // INPUTGENERATOR::SimpleEventGenerator[0]->set_pt_range(5, 5);
   }
   // Upsilons
   // if you run more than one of these Input::UPSILON_NUMBER > 1
@@ -284,7 +288,7 @@ int Fun4All_G4_sPHENIX(
   //======================
 
   // QA, main switch
-  Enable::QA = true;
+  Enable::QA = false;
 
   // Global options (enabled for all enables subsystems - if implemented)
   //  Enable::ABSORBER = true;
@@ -384,7 +388,7 @@ int Fun4All_G4_sPHENIX(
 
   Enable::CALOTRIGGER = Enable::CEMC_TOWER && Enable::HCALIN_TOWER && Enable::HCALOUT_TOWER && false;
 
-  Enable::JETS = (Enable::GLOBAL_RECO || Enable::GLOBAL_FASTSIM) && true;
+  Enable::JETS = (Enable::GLOBAL_RECO || Enable::GLOBAL_FASTSIM) && false;
   Enable::JETS_EVAL = Enable::JETS && true;
   Enable::JETS_QA = Enable::JETS && Enable::QA && true;
 

--- a/EMCal-position-dependent-calibration/src/RawClusterPositionCorrectionFull.h
+++ b/EMCal-position-dependent-calibration/src/RawClusterPositionCorrectionFull.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <vector>
+#include <math.h>
 
 class PHCompositeNode;
 class RawClusterContainer;
@@ -56,11 +57,14 @@ class RawClusterPositionCorrectionFull : public SubsysReco
 
   std::string _det_name;
 
-  const float tower_eta_mid = 47.5;
+  const double cluster_eta_max           = 1.152;
+  const double sector_phi_boundary_low   = -M_PI / 32.;
+  const double sector_phi_boundary_high  = M_PI / 32.;
+  const double sector_phi_boundary_width = sector_phi_boundary_high - sector_phi_boundary_low;
 
   int bins_eta, bins_phi;
-  std::vector<float> binvals_eta;
-  std::vector<float> binvals_phi;
+  std::vector<double> binvals_eta;
+  std::vector<double> binvals_phi;
   std::vector<std::vector<double> > eclus_calib_constants;
   std::vector<std::vector<double> > ecore_calib_constants;
 };


### PR DESCRIPTION
- Fun4All_G4_sPHENIX.C: Restricted the generation range to that of one sector.
- Fun4All_G4_sPHENIX.C: Disabled the default QA plots which are generated as well as disabled jets.
- RawClusterPositionCorrectionFull.cc: Added packages to compute pseudorapidity using a specified vertex.
- RawClusterPositionCorrectionFull.cc: Not using tower ids as intermediate process to compute the correction factor. Directly computing the correction factor from the eta and phi values of the cluster.
- RawClusterPositionCorrectionFull.cc and .h: Changed float to double for increased precision.