### PR TITLE
Adding XY position output to SampleTree

### DIFF
--- a/TPC/DAQ/TPCRawDataTree/Makefile.am
+++ b/TPC/DAQ/TPCRawDataTree/Makefile.am
@@ -21,6 +21,7 @@ libTPCRawDataTree_la_SOURCES = \
 
 
 libTPCRawDataTree_la_LIBADD = \
+  -ltpc \
   -lphool \
   -lSubsysReco
 

--- a/TPC/DAQ/TPCRawDataTree/TPCRawDataTree.cc
+++ b/TPC/DAQ/TPCRawDataTree/TPCRawDataTree.cc
@@ -29,6 +29,7 @@ TPCRawDataTree::TPCRawDataTree(const std::string &name)
 {
   // reserve memory for max ADC samples
   m_adcSamples.resize(1024, 0);
+  M.setMapNames("AutoPad-R1-RevA.sch.ChannelMapping.csv", "AutoPad-R2-RevA-Pads.sch.ChannelMapping.csv", "AutoPad-R3-RevA.sch.ChannelMapping.csv");
 }
 
 //____________________________________________________________________________..
@@ -39,6 +40,7 @@ int TPCRawDataTree::InitRun(PHCompositeNode *)
   sectorNum.erase(sectorNum.begin(),sectorNum.begin()+pos+8);
   sectorNum.erase(sectorNum.begin()+2,sectorNum.end());
   if(sectorNum.at(0) == '0') sectorNum.erase(sectorNum.begin(),sectorNum.begin()+1);
+  if(stoi(sectorNum) > 11) side = 1;
 
   m_file = TFile::Open(m_fname.c_str(), "recreate");
   assert(m_file->IsOpen());
@@ -100,17 +102,6 @@ int TPCRawDataTree::InitRun(PHCompositeNode *)
   {
     m_SampleTree->Branch("xPos", &m_xPos, "xPos/d");  
     m_SampleTree->Branch("yPos", &m_yPos, "yPos/d");  
-
-    R1_map = new TTree("R1_map","TPC Sector Mapping for R1");
-    R2_map = new TTree("R2_map","TPC Sector Mapping for R1");
-    R3_map = new TTree("R3_map","TPC Sector Mapping for R1");
-
-    R1_map->ReadFile("/sphenix/u/rosstom/calibrations/TPC/Mapping/PadPlane/AutoPad-R1-RevA.sch.ChannelMapping.csv",
-               "Entry/I:Radius/I:Pad/I:U/I:G/I:Pin/C:PinColID/I:PinRowID/I:PadName/C:FEE/F:FEE_Connector/C:FEE_Chan/I:phi/D:x/D:y/D:PadX/D:PadY/D:PadR/D:PadPhi/D",',');
-    R2_map->ReadFile("/sphenix/u/rosstom/calibrations/TPC/Mapping/PadPlane/AutoPad-R2-RevA-Pads.sch.ChannelMapping.csv",
-               "Entry/I:Radius/I:Pad/I:U/I:G/I:Pin/C:PinColID/I:PinRowID/I:PadName/C:FEE/F:FEE_Connector/C:FEE_Chan/I:phi/D:x/D:y/D:PadX/D:PadY/D:PadR/D:PadPhi/D",',');
-    R3_map->ReadFile("/sphenix/u/rosstom/calibrations/TPC/Mapping/PadPlane/AutoPad-R3-RevA.sch.ChannelMapping.csv",
-               "Entry/I:Radius/I:Pad/I:U/I:G/I:Pin/C:PinColID/I:PinRowID/I:PadName/C:FEE/F:FEE_Connector/C:FEE_Chan/I:phi/D:x/D:y/D:PadX/D:PadY/D:PadR/D:PadPhi/D",',');  
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -221,22 +212,24 @@ int TPCRawDataTree::process_event(PHCompositeNode *topNode)
       }
       if(m_includeXYPos)
       {
-        TTree* mapping = nullptr;
-        if (mod_arr[m_fee] == 1)
+        int feeM = FEE_map[m_fee];
+        if(FEE_R[m_fee]==2) feeM += 6;
+        if(FEE_R[m_fee]==3) feeM += 14;
+        int layer = M.getLayer(feeM, m_Channel);
+        if(layer!=0)
         {
-          mapping = R1_map;
+          double R = M.getR(feeM, m_Channel);
+          double phi = M.getPhi(feeM, m_Channel) + (stod(sectorNum) - side*12. )* M_PI / 6. ;
+          R /= 10.; //convert mm to cm  
+ 
+          m_xPos = R*cos(phi);
+          m_yPos = R*sin(phi);
         }
-        else if (mod_arr[m_fee] == 2)
+        else
         {
-          mapping = R2_map;
+          m_xPos = 0.;
+          m_yPos = 0.;
         }
-        else if (mod_arr[m_fee] == 3)
-        {
-          mapping = R3_map;
-        }
-        TVector2 position = getBinPosition(stoi(sectorNum), m_fee, m_Channel, mapping);
-        m_xPos = position.X();
-        m_yPos = position.Y();
       }
       m_SampleTree->Fill();
     }
@@ -266,46 +259,4 @@ int TPCRawDataTree::End(PHCompositeNode * /*topNode*/)
   m_file->Close();
 
   return Fun4AllReturnCodes::EVENT_OK;
-}
-
-TVector2 TPCRawDataTree::getBinPosition(int sectorNumber, int feeNumber, int channelNumber, TTree* segmentMapping)
-{
-  float slot[26] = {5,6,1,3,2,12,10,11,9,8,7,1,2,4,8,7,6,5,4,3,1,3,2,4,6,5};
-  //TTreeReader* myReader;
-  //myReader = new TTreeReader(segmentMapping);
-  
-  //TTreeReaderValue<Float_t> FEE(*myReader, "FEE");
-  //TTreeReaderValue<Int_t> FEE_Chan(*myReader, "FEE_Chan");
-  //TTreeReaderValue<Double_t> phi(*myReader, "phi");
-  //TTreeReaderValue<Double_t> PadR(*myReader, "PadR");
-
-  Float_t FEE;
-  Int_t FEE_Chan;
-  Double_t phi, PadR;
- 
-  segmentMapping->SetBranchAddress("FEE",&FEE);
-  segmentMapping->SetBranchAddress("FEE_Chan",&FEE_Chan);
-  segmentMapping->SetBranchAddress("phi",&phi);
-  segmentMapping->SetBranchAddress("PadR",&PadR);
-
-  double phiOffset;
-  if (sectorNumber < 12) phiOffset = 2*M_PI*((double)sectorNumber/12.) - 2*M_PI*(1./12.)/2;
-  else phiOffset = 2*M_PI*(((double)sectorNumber-12.)/12.) - 2*M_PI*(1./12.)/2;
-
-  int nEntries = segmentMapping->GetEntries();
-  for(int l = 0; l < nEntries; l++)
-  {
-    segmentMapping->GetEntry(l);
-    if (slot[feeNumber]-1 == FEE && channelNumber == FEE_Chan)
-    {
-      double x = (PadR/10)*std::cos(phi+phiOffset);
-      double y = (PadR/10)*std::sin(phi+phiOffset);
-      TVector2 pos;
-      pos.SetX(x); pos.SetY(y);
-      return pos;
-    }
-  }
-  TVector2 pos;
-  pos.SetX(0); pos.SetY(0);
-  return pos;
 }

--- a/TPC/DAQ/TPCRawDataTree/TPCRawDataTree.h
+++ b/TPC/DAQ/TPCRawDataTree/TPCRawDataTree.h
@@ -5,6 +5,8 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <tpc/TpcMap.h>
+
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -54,17 +56,18 @@ class TPCRawDataTree : public SubsysReco
  protected:
   //! which packet to decode
   std::vector<int> m_packets;
+  TpcMap M;
 
  private:
-  bool m_includeXYPos = false;
+  bool m_includeXYPos = true;
   std::string m_fname;
   TFile *m_file = nullptr;
   TTree *m_SampleTree = nullptr;
   TTree *m_PacketTree = nullptr;
   TTree *m_TaggerTree = nullptr;
-  TTree *R1_map = nullptr;
-  TTree *R2_map = nullptr;
-  TTree *R3_map = nullptr;
+  //TTree *R1_map = nullptr;
+  //TTree *R2_map = nullptr;
+  //TTree *R3_map = nullptr;
   TH1F *R1_hist = nullptr;
   TH1F *R2_hist = nullptr;
   TH1F *R3_hist = nullptr;
@@ -92,6 +95,7 @@ class TPCRawDataTree : public SubsysReco
   int m_BCO = 0;
   int m_checksum = 0;
   int m_checksumError = 0;
+  int side = 0;
   double m_xPos = 0.;
   double m_yPos = 0.;
 
@@ -110,7 +114,9 @@ class TPCRawDataTree : public SubsysReco
 
   std::vector<unsigned short> m_adcSamples;
 
-  int mod_arr[26] = {2,2,1,1,1,3,3,3,3,3,3,2,2,1,2,2,1,1,2,2,3,3,3,3,3,3};
+  int FEE_R[26]={2, 2, 1, 1, 1, 3, 3, 3, 3, 3, 3, 2, 2, 1, 2, 2, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3};
+  int FEE_map[26]={3, 2, 5, 3, 4, 0, 2, 1, 3, 4, 5, 7, 6, 2, 0, 1, 0, 1, 4, 5, 11, 9, 10, 8, 6, 7};
+  int pads_per_sector[3] = {96, 128, 192};
 };
 
 #endif  // TPCRawDataTree_H

--- a/TPC/DAQ/TPCRawDataTree/TPCRawDataTree.h
+++ b/TPC/DAQ/TPCRawDataTree/TPCRawDataTree.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <TVector2.h>
 
 class PHCompositeNode;
 class TFile;
@@ -37,21 +38,33 @@ class TPCRawDataTree : public SubsysReco
   /// Called at the end of all processing.
   int End(PHCompositeNode *topNode) override;
 
+  TVector2 getBinPosition(int sectorNumber, int feeNumber, int channelNumber, TTree* segmentMapping);
+
+
   void AddPacket(int packet)
   {
     m_packets.push_back(packet);
   }
 
+  void includeXYPos(bool doInclude)
+  {
+    m_includeXYPos = doInclude;
+  }
+ 
  protected:
   //! which packet to decode
   std::vector<int> m_packets;
 
  private:
+  bool m_includeXYPos = false;
   std::string m_fname;
   TFile *m_file = nullptr;
   TTree *m_SampleTree = nullptr;
   TTree *m_PacketTree = nullptr;
   TTree *m_TaggerTree = nullptr;
+  TTree *R1_map = nullptr;
+  TTree *R2_map = nullptr;
+  TTree *R3_map = nullptr;
   TH1F *R1_hist = nullptr;
   TH1F *R2_hist = nullptr;
   TH1F *R3_hist = nullptr;
@@ -65,6 +78,7 @@ class TPCRawDataTree : public SubsysReco
   TH2F *R2_time = nullptr;
   TH2F *R3_time = nullptr;
 
+  std::string sectorNum;
 
   int m_packet = 0;
   int m_frame = 0;
@@ -78,6 +92,8 @@ class TPCRawDataTree : public SubsysReco
   int m_BCO = 0;
   int m_checksum = 0;
   int m_checksumError = 0;
+  double m_xPos = 0.;
+  double m_yPos = 0.;
 
   int m_nTaggerInFrame = 0;
   uint16_t m_tagger_type = 0;
@@ -93,6 +109,8 @@ class TPCRawDataTree : public SubsysReco
   uint64_t m_last_lvl1_bco = 0;
 
   std::vector<unsigned short> m_adcSamples;
+
+  int mod_arr[26] = {2,2,1,1,1,3,3,3,3,3,3,2,2,1,2,2,1,1,2,2,3,3,3,3,3,3};
 };
 
 #endif  // TPCRawDataTree_H

--- a/TPC/DAQ/TPCRawDataTree/TPCRawDataTree.h
+++ b/TPC/DAQ/TPCRawDataTree/TPCRawDataTree.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
-#include <TVector2.h>
 
 class PHCompositeNode;
 class TFile;
@@ -39,9 +38,6 @@ class TPCRawDataTree : public SubsysReco
 
   /// Called at the end of all processing.
   int End(PHCompositeNode *topNode) override;
-
-  TVector2 getBinPosition(int sectorNumber, int feeNumber, int channelNumber, TTree* segmentMapping);
-
 
   void AddPacket(int packet)
   {
@@ -116,7 +112,6 @@ class TPCRawDataTree : public SubsysReco
 
   int FEE_R[26]={2, 2, 1, 1, 1, 3, 3, 3, 3, 3, 3, 2, 2, 1, 2, 2, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3};
   int FEE_map[26]={3, 2, 5, 3, 4, 0, 2, 1, 3, 4, 5, 7, 6, 2, 0, 1, 0, 1, 4, 5, 11, 9, 10, 8, 6, 7};
-  int pads_per_sector[3] = {96, 128, 192};
 };
 
 #endif  // TPCRawDataTree_H


### PR DESCRIPTION
Adds option to save the x,y position of the channel associated with the waveform in SampleTree to make it easier to display hit positions. Use the includeXYPos function set to true to save this because the default is to not save these values