### PR TITLE
djl -- adding centrality validation package

### DIFF
--- a/Centrality_Validation_Package/CentralityValid.cc
+++ b/Centrality_Validation_Package/CentralityValid.cc
@@ -1,0 +1,111 @@
+#include "CentralityValid.h"
+
+#include <centrality/CentralityInfo.h>
+#include <calotrigger/MinimumBiasInfo.h>
+#include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/PHRandomSeed.h>
+#include <phool/getClass.h>
+
+#include <TF1.h>
+#include <TEfficiency.h>
+#include <TFile.h>
+#include <TH2.h>
+#include <TNtuple.h>
+#include <TSystem.h>
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+CentralityValid::CentralityValid(const std::string &name, const std::string &hist_name)
+  : SubsysReco(name)
+{
+  _hist_filename = hist_name;
+}
+
+CentralityValid::~CentralityValid()
+{
+  delete hm;
+}
+int CentralityValid::Init(PHCompositeNode * /*unused*/)
+{
+  // Histograms
+
+  hm = new Fun4AllHistoManager("CENTRALITY_VALIDATION_HIST");
+
+  _h_centrality_bin = new TH1D("h_centrality_bin", ";Centrality Bin; 1/N{_Events}",20,-0.025, 0.975);
+  _h_centrality_bin_mb = new TH1D("h_centrality_bin_mb", ";Centrality Bin; 1/N{_Events}",20,-0.025, 0.975);
+
+  _he_min_bias = new TEfficiency("he_min_bias",";Min Bias?; Fraction of Events", 1, 0, 1);
+  hm->registerHisto(_h_centrality_bin);
+  hm->registerHisto(_h_centrality_bin_mb);
+  hm->registerHisto(_he_min_bias);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CentralityValid::InitRun(PHCompositeNode * /*unused*/)
+{
+  if (Verbosity())
+  {
+    std::cout << __FILE__ << " :: " << __FUNCTION__ << std::endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+int CentralityValid::process_event(PHCompositeNode *topNode)
+{
+  if (Verbosity())
+  {
+    std::cout << __FILE__ << " :: " << __FUNCTION__ << " :: " << __LINE__ << std::endl;
+  }
+
+  _central = findNode::getClass<CentralityInfo>(topNode, "CentralityInfo");
+  
+  if (!_central)
+  {
+    std::cout << "no centrality node " << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  _minimumbiasinfo = findNode::getClass<MinimumBiasInfo>(topNode, "MinimumBiasInfo");
+  
+  if (!_minimumbiasinfo)
+  {
+    std::cout << "no minimumbias node " << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  float centile = (_central->has_centile(CentralityInfo::PROP::mbd_NS)?_central->get_centile(CentralityInfo::PROP::mbd_NS) : -999.99);
+
+  _h_centrality_bin->Fill(centile);
+
+  bool isMinBias = _minimumbiasinfo->isAuAuMinimumBias();
+
+  if (isMinBias)
+    {
+      _h_centrality_bin_mb->Fill(centile);
+    }
+  _he_min_bias->Fill(isMinBias,0);
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CentralityValid::End(PHCompositeNode * /* topNode*/)
+{
+  hm->dumpHistos(_hist_filename.c_str(), "RECREATE");
+
+  return 0;
+}

--- a/Centrality_Validation_Package/CentralityValid.h
+++ b/Centrality_Validation_Package/CentralityValid.h
@@ -1,0 +1,51 @@
+#ifndef CENTRALITY_VALIDATION_H
+#define CENTRALITY_VALIDATION_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <limits>
+
+// Forward declarations
+class CentralityInfo;
+class MinimumBiasInfo;
+class Fun4AllHistoManager;
+class PHCompositeNode;
+class TH1;
+class TEfficiency;
+
+class CentralityValid : public SubsysReco
+{
+ public:
+  //! constructor
+  explicit CentralityValid(const std::string &name = "CentralityValid", const std::string &hist_name = "QA_CentralityReco.root");
+
+  //! destructor
+  virtual ~CentralityValid();
+
+  //! full initialization
+  int Init(PHCompositeNode *);
+  int InitRun(PHCompositeNode *);
+
+  int process_event(PHCompositeNode *);
+  
+  //! end of run method
+  int End(PHCompositeNode *);
+
+ protected:
+
+  Fun4AllHistoManager *hm = nullptr;
+
+  CentralityInfo *_central = nullptr;
+  MinimumBiasInfo *_minimumbiasinfo = nullptr;
+
+  std::string _hist_filename;
+
+  TH1 *_h_centrality_bin = nullptr;
+ 
+  TH1 *_h_centrality_bin_mb = nullptr;
+
+  TEfficiency *_he_min_bias = nullptr;
+  
+};
+
+#endif

--- a/Centrality_Validation_Package/Makefile.am
+++ b/Centrality_Validation_Package/Makefile.am
@@ -1,0 +1,52 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include  \
+  -isystem`root-config --incdir`
+
+lib_LTLIBRARIES = \
+   libcentralityvalid.la
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(ROOTSYS)/lib
+
+libcentralityvalid_la_LIBADD = \
+  -lfun4all \
+  -lcentrality \
+  -lcalotrigger
+
+pkginclude_HEADERS = \
+  CentralityValid.h
+
+libcentralityvalid_la_SOURCES = \
+  CentralityValid.cc
+
+# Rule for generating table CINT dictionaries.
+%_Dict.cc: %.h %LinkDef.h
+	rootcint -f $@ @CINTDEFS@ $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+
+#just to get the dependency
+%_Dict_rdict.pcm: %_Dict.cc ;
+
+################################################
+# linking tests
+BUILT_SOURCES = testexternals.cc
+
+noinst_PROGRAMS = \
+  testexternals_centralityvalid
+
+testexternals_centralityvalid_SOURCES = testexternals.cc
+testexternals_centralityvalid_LDADD = libcentralityvalid.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f *Dict* $(BUILT_SOURCES) *.pcm

--- a/Centrality_Validation_Package/autogen.sh
+++ b/Centrality_Validation_Package/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"
+

--- a/Centrality_Validation_Package/configure.ac
+++ b/Centrality_Validation_Package/configure.ac
@@ -1,0 +1,16 @@
+AC_INIT(centrality,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+
+AC_PROG_CXX(CC g++)
+LT_INIT([disable-static])
+
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+
+CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+AC_SUBST(CINTDEFS)
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT
+


### PR DESCRIPTION
Added a centrality validation package that reads from the CentralityInfo and MinimumBiasInfo nodes. Adds three histograms. Counting events in each centrality bin and then a histogram showing the fraction of events that meet the AuAu minimum bias min bias definition.