### PR TITLE
Flag for pp vs AA figures added to TracksInJets.cc/.h

### DIFF
--- a/JS-Jet/TracksInJets/macro/Fun4All_JetVal.C
+++ b/JS-Jet/TracksInJets/macro/Fun4All_JetVal.C
@@ -11,10 +11,11 @@
 
 #include <phool/PHRandomSeed.h>
 #include <phool/recoConsts.h>
+#include <G4_Global.C>
 
-#include <g4jets/FastJetAlgo.h>
-#include <g4jets/JetReco.h>
-#include <g4jets/TowerJetInput.h>
+#include <jetbase/FastJetAlgo.h>
+#include <jetbase/JetReco.h>
+#include <jetbase/TowerJetInput.h>
 #include <g4jets/TruthJetInput.h>
 
 #include <g4centrality/PHG4CentralityReco.h>
@@ -22,6 +23,8 @@
 #include <HIJetReco.C>
 
 #include <tracksinjets/TracksInJets.h>
+//#include </sphenix/u/jamesj3j3/analysis/JS-Jet/TracksInJets/src/TracksInJets.h>
+
 
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libg4jets.so)
@@ -34,16 +37,25 @@ R__LOAD_LIBRARY(libg4dst.so)
 
 void Fun4All_JetVal(const char *filelisttrk = "dst_tracks.list",
 		    const char *filelistcalo = "dst_calo_cluster.list",
-		    const char *filelistbbc = "dst_bbc_g4hit.list",
+		    const char *filelistbbc = "dst_mbd_epd.list",
 		    const char *outname = "outputest.root")
 {
 
+  // Set do_global flag to true to enable reconstruction of the global vertex
   
   Fun4AllServer *se = Fun4AllServer::instance();
   int verbosity = 0;
 
   se->Verbosity(verbosity);
   recoConsts *rc = recoConsts::instance();
+
+  Enable::CDB = true;
+  // global tag
+  rc->set_StringFlag("CDB_GLOBALTAG",CDB::global_tag);
+  // 64 bit timestamp
+  rc->set_uint64Flag("TIMESTAMP",CDB::timestamp);
+
+  Global_Reco(); 
 
   PHG4CentralityReco *cent = new PHG4CentralityReco();
   cent->Verbosity(0);
@@ -52,7 +64,10 @@ void Fun4All_JetVal(const char *filelisttrk = "dst_tracks.list",
 
   HIJetReco();  
 
+  bool isAA = false; // Set the value of isAA for AA collisions. Produces figures projected accross centrality bins {0,100,10}. False for pp.
+
   TracksInJets *trksinjets = new TracksInJets("AntiKt_Tower_r04_Sub1", outname);
+
   se->registerSubsystem(trksinjets);  
   
   Fun4AllInputManager *in = new Fun4AllDstInputManager("DSTcalo");
@@ -67,7 +82,7 @@ void Fun4All_JetVal(const char *filelisttrk = "dst_tracks.list",
   inbbc->AddListFile(filelistbbc,1);
   se->registerInputManager(inbbc);
 
-  se->run(100);
+  se->run(1000);
   se->End();
 
   gSystem->Exit(0);

--- a/JS-Jet/TracksInJets/src/TracksInJets.cc
+++ b/JS-Jet/TracksInJets/src/TracksInJets.cc
@@ -194,24 +194,18 @@ int TracksInJets::End(PHCompositeNode *topNode)
   std::cout << "TracksInJets::End - Output to " << m_outputFileName << std::endl;
   PHTFileServer::get().cd(m_outputFileName);
 
-  bool isAA = false;
-  
   if (isAA) {
-    isAA = true;
-  
-  TH2 *h_proj;
-  for(int i = 0; i < m_h_track_vs_calo_pt->GetNbinsZ(); i++)
-    {
-      m_h_track_vs_calo_pt->GetZaxis()->SetRange(i+1,i+1);
-      h_proj = (TH2*) m_h_track_vs_calo_pt->Project3D("yx");
-      h_proj->Write(Form("h_track_vs_calo_%1.0f",m_h_track_vs_calo_pt->GetZaxis()->GetBinLowEdge(i+1)));
-    }
+    TH2 *h_proj;
+    for(int i = 0; i < m_h_track_vs_calo_pt->GetNbinsZ(); i++)
+      {
+	m_h_track_vs_calo_pt->GetZaxis()->SetRange(i+1,i+1);
+	h_proj = (TH2*) m_h_track_vs_calo_pt->Project3D("yx");
+	h_proj->Write(Form("h_track_vs_calo_%1.0f",m_h_track_vs_calo_pt->GetZaxis()->GetBinLowEdge(i+1)));
+      }
   }
-
-  if (isAA) {
-    isAA = false;
-    m_h_track_vs_calo_pt->Write();
-  } 
+  else {
+    m_h_track_vs_calo_pt->Write();  //if pp, do not project onto centrality bins
+  }
   std::cout << "TracksInJets::End(PHCompositeNode *topNode) This is the End..." << std::endl;  
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/JS-Jet/TracksInJets/src/TracksInJets.cc
+++ b/JS-Jet/TracksInJets/src/TracksInJets.cc
@@ -41,6 +41,7 @@
 
 #include "TH1.h"
 #include "TH2.h"
+#include "TH2F.h"
 #include <TTree.h>
 #include <TFile.h>
 #include <TH3F.h>
@@ -75,6 +76,9 @@ int TracksInJets::Init(PHCompositeNode *topNode)
   m_h_track_vs_calo_pt = new TH3F("m_h_track_vs_calo_pt","",100,0,100,500,0,100,10,0,100);
   m_h_track_vs_calo_pt->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
   m_h_track_vs_calo_pt->GetYaxis()->SetTitle("Sum track p_{T} [GeV]");
+  m_h_track_pt = new TH2F("m_h_track_pt", "", 100, 0, 100, 100, 0, 100);
+  m_h_track_pt->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
+  m_h_track_pt->GetYaxis()->SetTitle("Sum track p_{T} [GeV]");
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -166,8 +170,16 @@ int TracksInJets::process_event(PHCompositeNode *topNode)
 
     // Fill histogram for the current jet
     assert(m_h_track_vs_calo_pt);
-    m_h_track_vs_calo_pt->Fill(jet->get_pt(), sumtrk.Perp(), cent);
+    assert(m_h_track_pt);
+    // Fill TH3 histogram for Au+Au collisions
+    if (isAA) {
+      m_h_track_vs_calo_pt->Fill(jet->get_pt(), sumtrk.Perp(), cent);
+    }
 
+    // Fill TH2 histogram for pp collisions
+    else {
+      m_h_track_pt->Fill(jet->get_pt(), sumtrk.Perp());
+    }
     // Reset sumtrk for the next jet
     sumtrk.SetXYZ(0, 0, 0);
   }
@@ -204,7 +216,7 @@ int TracksInJets::End(PHCompositeNode *topNode)
       }
   }
   else {
-    m_h_track_vs_calo_pt->Write();  //if pp, do not project onto centrality bins
+    m_h_track_pt->Write();  //if pp, do not project onto centrality bins
   }
   std::cout << "TracksInJets::End(PHCompositeNode *topNode) This is the End..." << std::endl;  
   return Fun4AllReturnCodes::EVENT_OK;

--- a/JS-Jet/TracksInJets/src/TracksInJets.h
+++ b/JS-Jet/TracksInJets/src/TracksInJets.h
@@ -53,6 +53,8 @@ class TracksInJets : public SubsysReco
 
   void Print(const std::string &what = "ALL") const override;
 
+  bool isAA; // Declare isAA as a public member variable
+
  private:
 
   std::string m_recoJetName;

--- a/JS-Jet/TracksInJets/src/TracksInJets.h
+++ b/JS-Jet/TracksInJets/src/TracksInJets.h
@@ -7,6 +7,7 @@
 #include <fun4all/SubsysReco.h>
 #include "TTree.h"
 #include <string>
+#include "TH2F.h"
 
 class PHCompositeNode;
 class TH3;
@@ -62,7 +63,7 @@ class TracksInJets : public SubsysReco
   float m_jetRadius;
   std::string m_outputFileName;
   TH3 *m_h_track_vs_calo_pt;
-
+  TH2F *m_h_track_pt;
 };
 
 #endif // TRACKSINJETS_H


### PR DESCRIPTION
A flag was implemented such that isAA = true; The source code will find the jets and implement a 3D histogram with centralities projected onto it with the binning {0,100, 10} resulting in 10 histograms. If isAA = false; i.e pp collisions, then the 3D hist is not not projected with the centralities. The boolean is set in the Fun4All_JetVal.C which is all you need to change. 