### PR TITLE
Updated m_nSamples to be <= m_nadcSamples

### DIFF
--- a/TPC/DAQ/TPCRawDataTree/TPCRawDataTree.cc
+++ b/TPC/DAQ/TPCRawDataTree/TPCRawDataTree.cc
@@ -178,7 +178,7 @@ int TPCRawDataTree::process_event(PHCompositeNode *topNode)
       else{ fillHist=R3_hist; fillHist2D=R3_time;}
 
 
-      assert(m_nSamples < (int) m_adcSamples.size());  // no need for movements in memory allocation
+      assert(m_nSamples <= (int) m_adcSamples.size());  // no need for movements in memory allocation
       for (int s = 0; s < m_nSamples; s++)
       {
         m_adcSamples[s] = p->iValue(wf, s);


### PR DESCRIPTION
I noticed an issue where Fun4All_TPC_UnpackPRDF.C was failing to process recent data files. The cause of the issue seems to be that the sample number reaches the limit set for the adc samples. Updating TPCRawDataTree.cc to assert m_nSamples <= m_adcSamples resolves this issue.