### PR TITLE
Bug Fix for Jet Background Cut module

### DIFF
--- a/joclJetBackgroundCutModule/src/jetBackgroundCut.cc
+++ b/joclJetBackgroundCutModule/src/jetBackgroundCut.cc
@@ -9,7 +9,6 @@
 #include <calobase/TowerInfoContainerSimv1.h>
 #include <calobase/TowerInfoContainerSimv2.h>
 #include <globalvertex/GlobalVertexMapv1.h>
-#include <globalvertex/GlobalVertex.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
@@ -20,7 +19,6 @@
 #include <jetbase/Jet.h>
 #include <iostream>
 #include <ffarawobjects/Gl1Packetv2.h>
-#include <globalvertex/GlobalVertex.h>
 using namespace std;
 
 //____________________________________________________________________________..
@@ -84,7 +82,7 @@ int jetBackgroundCut::process_event(PHCompositeNode *topNode)
     }
   if(gvtxmap)
     {
-      GlobalVertex* gvtx = gvtxmap->Get(_vtxtype);
+      GlobalVertex* gvtx = gvtxmap->get(_vtxtype);
       if(gvtx)
 	{
 	  zvtx = gvtx->get_z();

--- a/joclJetBackgroundCutModule/src/jetBackgroundCut.h
+++ b/joclJetBackgroundCutModule/src/jetBackgroundCut.h
@@ -5,14 +5,14 @@
 #include <string>
 #include <cmath>
 #include <phool/recoConsts.h>
-#include <globalvertex/GlobalVeretx.h>
+#include <globalvertex/GlobalVertex.h>
 class PHCompositeNode;
 class CentralityInfo;
 class jetBackgroundCut : public SubsysReco
 {
  public:
 
-  jetBackgroundCut(const std::string jetNodeName, const std::string &name = "jetBackgroundCutModule", const int debug = 0, const bool doAbort = 0, GlobalVertex::VTXTYPE vtxtype = MBD);
+  jetBackgroundCut(const std::string jetNodeName, const std::string &name = "jetBackgroundCutModule", const int debug = 0, const bool doAbort = 0, GlobalVertex::VTXTYPE vtxtype = GlobalVertex::MBD);
 
   virtual ~jetBackgroundCut();
 


### PR DESCRIPTION
- Removed extra includes from jetBackgroundCut.cc
- Fixed method name from Get -> get
- Fixed incorrect include name
- Need to use GlobalVertex namespace to access the MBD enum