### PR TITLE
Use PHParameters in beam-background filter module instead of RecoConsts

### DIFF
--- a/JS-Jet/BeamBackgroundFilterAndQA/README.md
+++ b/JS-Jet/BeamBackgroundFilterAndQA/README.md
@@ -1,7 +1,7 @@
 # Beam Background Filter and QA
 
 ### Authors:
-Hanpu Jiang, Derek Anderson, Noah Applegate
+Hanpu Jiang, Derek Anderson, Noah Applegate, Joey Clement
 
 ### Description:
 Development repo for a F4A module to filter out events with significant beam

--- a/JS-Jet/BeamBackgroundFilterAndQA/src/BeamBackgroundFilterAndQA.cc
+++ b/JS-Jet/BeamBackgroundFilterAndQA/src/BeamBackgroundFilterAndQA.cc
@@ -11,9 +11,9 @@
 
 #define BEAMBACKGROUNDFILTERANDQA_CC
 
-// c++ utiilites
-#include <cassert>
-#include <iostream>
+// module components
+#include "BeamBackgroundFilterAndQA.h"
+#include "BeamBackgroundFilterAndQADefs.h"
 
 // calo base
 #include <calobase/TowerInfoContainer.h>
@@ -35,9 +35,9 @@
 // root libraries
 #include <TH1.h>
 
-// module components
-#include "BeamBackgroundFilterAndQA.h"
-#include "BeamBackgroundFilterAndQADefs.h"
+// c++ utiilites
+#include <cassert>
+#include <iostream>
 
 // alias for convenience
 namespace bbfqd = BeamBackgroundFilterAndQADefs;
@@ -51,6 +51,8 @@ namespace bbfqd = BeamBackgroundFilterAndQADefs;
 // ----------------------------------------------------------------------------
 BeamBackgroundFilterAndQA::BeamBackgroundFilterAndQA(const std::string& name, const bool debug)
   : SubsysReco(name)
+  , m_manager(nullptr)
+  , m_flags(name)
 {
 
   // print debug message
@@ -69,7 +71,7 @@ BeamBackgroundFilterAndQA::BeamBackgroundFilterAndQA(const std::string& name, co
 BeamBackgroundFilterAndQA::BeamBackgroundFilterAndQA(const Config& config)
   : SubsysReco(config.moduleName)
   , m_manager(nullptr)
-  , m_consts(nullptr)
+  , m_flags(config.moduleName)
   , m_config(config)
 {
 
@@ -106,7 +108,7 @@ BeamBackgroundFilterAndQA::~BeamBackgroundFilterAndQA()
 // ----------------------------------------------------------------------------
 //! Initialize module
 // ----------------------------------------------------------------------------
-int BeamBackgroundFilterAndQA::Init(PHCompositeNode* /*topNode*/)
+int BeamBackgroundFilterAndQA::Init(PHCompositeNode* topNode)
 {
 
   if (m_config.debug)
@@ -116,7 +118,7 @@ int BeamBackgroundFilterAndQA::Init(PHCompositeNode* /*topNode*/)
 
   // initialize relevant filters, histograms
   InitFilters();
-  InitFlags();
+  InitFlags(topNode);
   BuildHistograms();
 
   // if needed, initialize histograms + manager
@@ -142,13 +144,19 @@ int BeamBackgroundFilterAndQA::process_event(PHCompositeNode* topNode)
     std::cout << "BeamBackgroundFilterAndQA::process_event(PHCompositeNode *topNode) Processing event" << std::endl;
   }
 
+  // reset flags
+  SetDefaultFlags();
+
   // check for beam background
   const bool hasBeamBkgd = ApplyFilters(topNode);
+
+  // update flags on node tree
+  UpdateFlags(topNode);
 
   // if debugging, print out flags
   if (m_config.debug)
   {
-    m_consts->PrintIntFlags();
+    m_flags.printint();
   }
 
   // if it does, abort event
@@ -209,21 +217,29 @@ void BeamBackgroundFilterAndQA::InitFilters()
 // ----------------------------------------------------------------------------
 //! Initialize flags
 // ----------------------------------------------------------------------------
-void BeamBackgroundFilterAndQA::InitFlags()
+void BeamBackgroundFilterAndQA::InitFlags(PHCompositeNode* topNode)
 {
 
   // print debug message
   if (m_config.debug && (Verbosity() > 1))
   {
-    std::cout << "BeamBackgroundFilterAndQA::InitFlags() Initializing reco consts and flags" << std::endl;
+    std::cout << "BeamBackgroundFilterAndQA::InitFlags() Initializing flags" << std::endl;
   }
 
-  m_consts = recoConsts::instance();
-  for (const std::string& filterToApply : m_config.filtersToApply)
+  // add node for flags
+  PHNodeIterator itNode(topNode);
+  PHCompositeNode* parNode = dynamic_cast<PHCompositeNode*>(itNode.findFirst("PHCompositeNode", "PAR"));
+  if (!parNode)
   {
-    m_consts->set_IntFlag("HasBeamBackground_" + filterToApply + "Filter", 0);
+    std::cerr << PHWHERE << " WARNING: No PAR node found! Cannot add node for background flags to node tree!" << std::endl;
   }
-  m_consts->set_IntFlag("HasBeamBackground", 0);
+  else
+  {
+    m_flags.SaveToNodeTree(parNode, m_config.flagPrefix);
+  }
+
+  // initialize flags
+  SetDefaultFlags();
   return;
 
 }  // end 'InitFlags()'
@@ -326,6 +342,54 @@ void BeamBackgroundFilterAndQA::RegisterHistograms()
 
 
 // ----------------------------------------------------------------------------
+//! Set default values of flags
+// ----------------------------------------------------------------------------
+void BeamBackgroundFilterAndQA::SetDefaultFlags()
+{
+
+  // print debug message
+  if (m_config.debug && (Verbosity() > 1))
+  {
+    std::cout << "BeamBackgroundFilterAndQA::SetDefaultFlags() Setting defuault flag values" << std::endl;
+  }
+
+  // set default values
+  for (const std::string& filterToApply : m_config.filtersToApply)
+  {
+    m_flags.set_int_param(MakeFlagName(filterToApply), 0);
+  }
+  m_flags.set_int_param(MakeFlagName(), 0);
+  return;
+
+}  // end 'SetDefaultFlags()'
+
+
+
+// ----------------------------------------------------------------------------
+//! Update flags on the node tree
+// ----------------------------------------------------------------------------
+void BeamBackgroundFilterAndQA::UpdateFlags(PHCompositeNode* topNode)
+{
+
+  // print debug message
+  if (m_config.debug && (Verbosity() > 0))
+  {
+    std::cout << "BeamBackgroundFilterAndQA::UpdateFlags(PHCompositeNode*) Updating flags on the node tree" << std::endl;
+  }
+
+  PHNodeIterator itNode(topNode);
+  PHCompositeNode* parNode = dynamic_cast<PHCompositeNode*>(itNode.findFirst("PHCompositeNode", "PAR"));
+  if (parNode)
+  {
+    m_flags.UpdateNodeTree(parNode, m_config.flagPrefix);
+  }
+  return;
+
+}  // end 'UpdateFlags(PHCompositeNode*)'
+
+
+
+// ----------------------------------------------------------------------------
 //! Apply relevant filters
 // ----------------------------------------------------------------------------
 bool BeamBackgroundFilterAndQA::ApplyFilters(PHCompositeNode* topNode)
@@ -345,7 +409,7 @@ bool BeamBackgroundFilterAndQA::ApplyFilters(PHCompositeNode* topNode)
     if (filterFoundBkgd)
     {
       m_hists["nevts_" + filterToApply]->Fill(bbfqd::Status::HasBkgd);
-      m_consts->set_IntFlag("HasBeamBackground_" + filterToApply + "Filter", 1);
+      m_flags.set_int_param(MakeFlagName(filterToApply), 1);
     }
     else
     {
@@ -360,7 +424,7 @@ bool BeamBackgroundFilterAndQA::ApplyFilters(PHCompositeNode* topNode)
   if (hasBkgd)
   {
     m_hists["nevts_overall"]->Fill(bbfqd::Status::HasBkgd);
-    m_consts->set_IntFlag("HasBeamBackground", 1);
+    m_flags.set_int_param(MakeFlagName(), 1);
   }
   else
   {
@@ -369,5 +433,36 @@ bool BeamBackgroundFilterAndQA::ApplyFilters(PHCompositeNode* topNode)
   return hasBkgd;
 
 }  // end 'ApplyFilters(PHCompositeNode*)'
+
+
+
+// ----------------------------------------------------------------------------
+//! Create flag name
+// ----------------------------------------------------------------------------
+/*! Helper method to create a flag (PHParameters) name from a
+ *  provided filter name.  If no filter is provided, method
+ *  will return just the flag prefix.
+ */
+std::string BeamBackgroundFilterAndQA::MakeFlagName(const std::string& filter)
+{
+
+  // print debug message
+  if (m_config.debug && (Verbosity() > 2))
+  {
+    std::cout << "BeamBackgroundFilterAndQA::MakeFlagName(std::string&) Creating flag name" << std::endl;
+  }
+
+  // by default, return flag prefix; otherwise,
+  // combine prefix and filter name
+  if (filter.empty())
+  {
+    return m_config.flagPrefix;
+  }
+  else
+  {
+    return m_config.flagPrefix + "_" + filter + "Filter";
+  }
+
+}  // end 'MakeFlagName(std::string&)'
 
 // end ========================================================================

--- a/JS-Jet/BeamBackgroundFilterAndQA/src/BeamBackgroundFilterAndQA.cc
+++ b/JS-Jet/BeamBackgroundFilterAndQA/src/BeamBackgroundFilterAndQA.cc
@@ -27,7 +27,6 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 #include <phool/PHCompositeNode.h>
-#include <phool/recoConsts.h>
 
 // qa utilities
 #include <qautils/QAHistManagerDef.h>

--- a/JS-Jet/BeamBackgroundFilterAndQA/src/BeamBackgroundFilterAndQA.h
+++ b/JS-Jet/BeamBackgroundFilterAndQA/src/BeamBackgroundFilterAndQA.h
@@ -12,25 +12,27 @@
 #ifndef BEAMBACKGROUNDFILTERANDQA_H
 #define BEAMBACKGROUNDFILTERANDQA_H
 
+// module components
+#include "BaseBeamBackgroundFilter.h"
+#include "NullFilter.h"
+#include "StreakSidebandFilter.h"
+
+// f4a libraries
+#include <fun4all/SubsysReco.h>
+
+// phparameters libraries
+#include <phparameter/PHParameters.h>
+
 // c++ utilities
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
-// f4a libraries
-#include <fun4all/SubsysReco.h>
-
-// module components
-#include "BaseBeamBackgroundFilter.h"
-#include "NullFilter.h"
-#include "StreakSidebandFilter.h"
-
 // forward declarations
 class Fun4AllHistoManager;
 class PHCompositeNode;
 class QAHistManagerHistDef;
-class recoConsts;
 class TowerInfoContainer;
 
 
@@ -60,6 +62,9 @@ class BeamBackgroundFilterAndQA : public SubsysReco {
       ///! module name
       std::string moduleName = "BeamBackgroundFilterAndQA";
 
+      ///! flag prefix
+      std::string flagPrefix = "HasBeamBackground";
+
       ///! histogram tags
       std::string histTag = "";
 
@@ -85,7 +90,7 @@ class BeamBackgroundFilterAndQA : public SubsysReco {
     Config GetConfig() const {return m_config;}
 
     // f4a methods
-    int Init(PHCompositeNode* /*topNode*/) override;
+    int Init(PHCompositeNode* topNode) override;
     int process_event(PHCompositeNode* topNode) override;
     int End(PHCompositeNode* /*topNode*/) override;
 
@@ -93,17 +98,20 @@ class BeamBackgroundFilterAndQA : public SubsysReco {
 
     // private methods
     void InitFilters();
-    void InitFlags();
+    void InitFlags(PHCompositeNode* topNode);
     void InitHistManager();
     void BuildHistograms();
     void RegisterHistograms();
+    void SetDefaultFlags();
+    void UpdateFlags(PHCompositeNode* topNode);
     bool ApplyFilters(PHCompositeNode* topNode);
+    std::string MakeFlagName(const std::string& filter = "");
 
     ///! histogram manager
     Fun4AllHistoManager* m_manager;
 
-    ///! reco consts (for flags)
-    recoConsts* m_consts;
+    ///! background flags
+    PHParameters m_flags;
 
     ///! module-wide histograms
     std::map<std::string, TH1*> m_hists;

--- a/JS-Jet/BeamBackgroundFilterAndQA/src/Makefile.am
+++ b/JS-Jet/BeamBackgroundFilterAndQA/src/Makefile.am
@@ -40,6 +40,7 @@ libbeambackgroundfilterandqa_la_LDFLAGS = \
   -lfun4all \
   -lg4detectors_io \
   -lphg4hit \
+  -lphparameter \
   -lg4dst \
   -lg4eval \
   -lqautils \

--- a/JS-Jet/BeamBackgroundFilterAndQA/src/Makefile.am
+++ b/JS-Jet/BeamBackgroundFilterAndQA/src/Makefile.am
@@ -39,6 +39,7 @@ libbeambackgroundfilterandqa_la_LDFLAGS = \
   -lcalo_io \
   -lfun4all \
   -lg4detectors_io \
+  -lpdbcalBase \
   -lphg4hit \
   -lphparameter \
   -lg4dst \

--- a/JS-Jet/BeamBackgroundFilterAndQA/src/TestPHFlags.h
+++ b/JS-Jet/BeamBackgroundFilterAndQA/src/TestPHFlags.h
@@ -13,16 +13,17 @@
 #ifndef TESTPHFLAGS_H
 #define TESTPHFLAGS_H
 
-// c++ utilities
-#include <string>
-
 // f4a libraries
 #include <fun4all/SubsysReco.h>
 
+// phparameter libraries
+#include <phparameter/PHParameters.h>
+
+// c++ utilities
+#include <string>
+
 // forward declarations
-class FlagSavev1;
 class PHCompositeNode;
-class recoConsts;
 
 
 
@@ -38,7 +39,7 @@ class TestPHFlags : public SubsysReco
   public:
 
     // ctor/dtor
-    TestPHFlags(const std::string &name = "TestPHFlags", const bool debug = false);
+    TestPHFlags(const std::string& name = "TestPHFlags", const std::string& flags = "HasBeamBackground", const bool debug = false);
     ~TestPHFlags() override;
 
     // f4a methods
@@ -46,11 +47,14 @@ class TestPHFlags : public SubsysReco
 
    private:
 
-     ///! reco consts (for flags)
-     recoConsts* m_consts;
+     ///! to retrieve flags
+     PHParameters m_flags;
 
      ///! turn on/off extra debugging messages
      bool m_doDebug;
+
+     ///! name of node where flags are stored
+     std::string m_flagNode;
 
 };  // end TestPHFlags
 


### PR DESCRIPTION
This PR updates the modules `BeamBackgroundFilterAndQA` and `TestPHFlags` to use `PHParameters` instead of `recoConsts` to persist the results of the beam-background filters.