### PR TITLE
SpinDBQA added crossing angle variance check to QA

### DIFF
--- a/SpinDBQA/SpinDBQA.cc
+++ b/SpinDBQA/SpinDBQA.cc
@@ -116,6 +116,7 @@ void SpinDBQA::doQA()
       if (runnumber >= 45236){GL1pScalersQA(stringMarkdown,stringHtml);}
       else{stringHtml += "GL1p Scalers: <font color=\"#800080\">NOT AVAILABLE</font>; ";}
       LocalPolQA(stringMarkdown,stringHtml);
+      CrossingAngleQA(stringMarkdown,stringHtml);
       map_spindbqa_markdown[stringMarkdown].push_back(runnumber);
     }
     
@@ -310,6 +311,23 @@ void SpinDBQA::LocalPolQA(std::string &stringMarkdown, std::string &stringHtml)
     stringHtml += "Local Polarimetry: <font color=\"#11cf17\">GOOD</font>; ";
   }
     // if CNI does not have beam polarizations (see if you can get polarizations from local pol)
+}
+
+void SpinDBQA::CrossingAngleQA(std::string &stringMarkdown, std::string &stringHtml) {
+  // Run crossing angle QA. Simply check the standard deviation per run and cut on a hard threshold.
+  // Currently set to cut three most egregious runs where beams switch from 1.5 mrad to/from head on.
+
+  // Check if crossing angle std exists and if it is above the threshold mark it as bad, good otherwise
+  if (map_crossanglestd[runnumber] > _crossanglestdthreshold)
+  {
+    stringMarkdown += "\u274C Crossing angle variation ";
+    stringHtml += "Crossing angle variation: <font color=\"#ff0000\">BAD</font>; ";
+  }
+  else
+  {
+    stringMarkdown += "\u2705 Crossing angle variation ";
+    stringHtml += "Crossing angle variation: <font color=\"#11cf17\">GOOD</font>; ";
+  }
 }
 
 void SpinDBQA::WriteMarkdown()

--- a/SpinDBQA/SpinDBQA.h
+++ b/SpinDBQA/SpinDBQA.h
@@ -27,6 +27,7 @@ public:
     void SetHtmlFilename(std::string htmlfile = "runsummary.html"){_htmlfilename = htmlfile;};
 
     void SetRunList(std::string runlist);
+    void SetCrossingAngleStdThreshold(float threshold){_crossanglestdthreshold = threshold;};
 
     void DefaultQA(){b_defaultQA = true;};
     void SetQALevel(int level){b_defaultQA = false; qalevel = level;};
@@ -48,6 +49,7 @@ private:
     void LocalPolQA(std::string &stringMarkdown,std::string &stringHtml);
     void GL1pScalersQA(std::string &stringMarkdown,std::string &stringHtml);
     void CNIHjetQA(std::string &stringMarkdown,std::string &stringHtml);
+    void CrossingAngleQA(std::string &stringMarkdown,std::string &stringHtml);
 
     void PrepareHtml();
     std::string HtmlContent();
@@ -59,6 +61,8 @@ private:
     std::string _cnipathname = "/gpfs02/eic/cnipol/jet_run24/results";
     std::string _markdownfilename;
     std::string _htmlfilename;
+
+    float _crossanglestdthreshold = 0.1;  // mrad, mark runs with crossing angle std above this threshold as bad. Not very elegant to have this hardcoded cut, Dylan's fault
 
     int runnumber;
 


### PR DESCRIPTION
Compare standard deviation of crossing angle for each run to hard-coded threshold of 0.1 mrad. If standard deviation is larger than this, mark as bad. Otherwise good. Untested.