### PR TITLE
PPG16: fixed MC output files

### DIFF
--- a/LightFlavorRatios/yield_and_ratios/Lambda_Kshort_ratio_MC.C
+++ b/LightFlavorRatios/yield_and_ratios/Lambda_Kshort_ratio_MC.C
@@ -15,8 +15,8 @@
 
 void Lambda_Kshort_ratio_MC()
 {
-  TFile* lambda_file = TFile::Open("../mass_histograms/merged_lambda_MC.root");
-  TFile* Ks_file = TFile::Open("../mass_histograms/merged_Kshort_MC.root");
+  TFile* lambda_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/LightFlavorProduction/merged_lambda_MC.root");
+  TFile* Ks_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/LightFlavorProduction/merged_Kshort_MC.root");
 
   //TFile* lambda_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/lambdaKshortMB/lambdaKshort_20260422_DetroitMB_CR_2_mode_pTref_1p4/ppi_reco/merged_lambda.root");
   //TFile* Ks_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/lambdaKshortMB/lambdaKshort_20260422_DetroitMB_CR_2_mode_pTref_1p4/pipi_reco/merged_kshort.root");

--- a/LightFlavorRatios/yield_and_ratios/Lambda_Kshort_ratio_MC_neg.C
+++ b/LightFlavorRatios/yield_and_ratios/Lambda_Kshort_ratio_MC_neg.C
@@ -13,10 +13,10 @@
 #include "LambdaModel.h"
 #include "KshortModel.h"
 
-void Lambda_Kshort_ratio_MC()
+void Lambda_Kshort_ratio_MC_neg()
 {
-  TFile* lambda_file = TFile::Open("../mass_histograms/merged_lambda_MC_neg.root");
-  TFile* Ks_file = TFile::Open("../mass_histograms/merged_Kshort_MC_neg.root");
+  TFile* lambda_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/LightFlavorProduction/merged_lambda_MC_neg.root");
+  TFile* Ks_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/LightFlavorProduction/merged_Kshort_MC_neg.root");
 
   //TFile* lambda_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/lambdaKshortMB/lambdaKshort_20260422_DetroitMB_CR_2_mode_pTref_1p4/ppi_reco/merged_lambda.root");
   //TFile* Ks_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/lambdaKshortMB/lambdaKshort_20260422_DetroitMB_CR_2_mode_pTref_1p4/pipi_reco/merged_kshort.root");
@@ -254,10 +254,10 @@ void Lambda_Kshort_ratio_MC()
   corrections[3].push_back(std::make_shared<GeoAcceptanceCorrection>("/sphenix/tg/tg01/hf/gregoryottino/lightFlavorPpg16/analysis/LightFlavorRatios/geometric_acceptance/analysis/plots_systemtics/Lambda0_to_KS0_geometric_acceptance_ratio_phi.root","Lambda0_inGeo_#phi"));
   corrections[3].push_back(std::make_shared<CutEfficiencyCorrection>("../swimming_correction/LamdbaKsCutEfficiency_200MeV_hists.root","hEffRatio_phi"));
 
-  TFile* fout = new TFile("fits_MC.root","RECREATE");
+  TFile* fout = new TFile("fits_MC_neg.root","RECREATE");
 
   ResonanceRatio analyzer(lambda_model,kshort_model,massbins_map,
-                          fout,"lambdaKsratio","(#Lambda^{0}+#bar{#Lambda^{0}})/2K_{S}^{0} ratio",1./2.,false,
+                          fout,"lambdaKsratio","#bar{#Lambda^{0}}/K_{S}^{0} ratio",1.,false,
                           diff_variables,corrections);
 
   analyzer.calculate_ratios_binned(integrated_lambda_mass,diff_lambda_data,integrated_kshort_mass,diff_ks_data);

--- a/LightFlavorRatios/yield_and_ratios/Lambda_Kshort_ratio_MC_pos.C
+++ b/LightFlavorRatios/yield_and_ratios/Lambda_Kshort_ratio_MC_pos.C
@@ -13,10 +13,10 @@
 #include "LambdaModel.h"
 #include "KshortModel.h"
 
-void Lambda_Kshort_ratio_MC()
+void Lambda_Kshort_ratio_MC_pos()
 {
-  TFile* lambda_file = TFile::Open("../mass_histograms/merged_lambda_MC_pos.root");
-  TFile* Ks_file = TFile::Open("../mass_histograms/merged_Kshort_MC_pos.root");
+  TFile* lambda_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/LightFlavorProduction/merged_lambda_MC_pos.root");
+  TFile* Ks_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/LightFlavorProduction/merged_Kshort_MC_pos.root");
 
   //TFile* lambda_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/lambdaKshortMB/lambdaKshort_20260422_DetroitMB_CR_2_mode_pTref_1p4/ppi_reco/merged_lambda.root");
   //TFile* Ks_file = TFile::Open("/sphenix/tg/tg01/hf/mjpeters/lambdaKshortMB/lambdaKshort_20260422_DetroitMB_CR_2_mode_pTref_1p4/pipi_reco/merged_kshort.root");
@@ -254,10 +254,10 @@ void Lambda_Kshort_ratio_MC()
   corrections[3].push_back(std::make_shared<GeoAcceptanceCorrection>("/sphenix/tg/tg01/hf/gregoryottino/lightFlavorPpg16/analysis/LightFlavorRatios/geometric_acceptance/analysis/plots_systemtics/Lambda0_to_KS0_geometric_acceptance_ratio_phi.root","Lambda0_inGeo_#phi"));
   corrections[3].push_back(std::make_shared<CutEfficiencyCorrection>("../swimming_correction/LamdbaKsCutEfficiency_200MeV_hists.root","hEffRatio_phi"));
 
-  TFile* fout = new TFile("fits_MC.root","RECREATE");
+  TFile* fout = new TFile("fits_MC_pos.root","RECREATE");
 
   ResonanceRatio analyzer(lambda_model,kshort_model,massbins_map,
-                          fout,"lambdaKsratio","(#Lambda^{0}+#bar{#Lambda^{0}})/2K_{S}^{0} ratio",1./2.,false,
+                          fout,"lambdaKsratio","#Lambda^{0}/K_{S}^{0} ratio",1.,false,
                           diff_variables,corrections);
 
   analyzer.calculate_ratios_binned(integrated_lambda_mass,diff_lambda_data,integrated_kshort_mass,diff_ks_data);


### PR DESCRIPTION
The MC Lambda/Ks ratio macros previously (accidentally) wrote to the same output file and all included the factor of 1/2 (which should only be present in the (Lambda+anti-Lambda)/2Ks ratio). They now write to different output files and include the proper scale factors.